### PR TITLE
Added method nearestPoints and refactored nearestPoint to use it

### DIFF
--- a/GEOSwift/SpatialAnalysis.swift
+++ b/GEOSwift/SpatialAnalysis.swift
@@ -84,14 +84,24 @@ public extension Geometry {
     
     /// - returns: The nearest point of this geometry with respect to `geometry`.
     func nearestPoint(_ geometry: Geometry) -> Coordinate {
-        let nearestPointsCoordinateList = GEOSNearestPoints_r(GEOS_HANDLE, self.geometry, geometry.geometry)
-        var x : Double = 0
-        var y : Double = 0
-        GEOSCoordSeq_getX_r(GEOS_HANDLE, nearestPointsCoordinateList, 0, &x)
-        GEOSCoordSeq_getY_r(GEOS_HANDLE, nearestPointsCoordinateList, 0, &y)
-        return Coordinate(x: x, y: y)
+        return nearestPoints(geometry)[0]
     }
-
+    
+    /// - returns: The nearest points in the geometries, ownership to caller.
+    func nearestPoints(_ geometry: Geometry) -> [Coordinate] {
+        let nearestPointsCoordinateList = GEOSNearestPoints_r(GEOS_HANDLE, self.geometry, geometry.geometry)
+        var x0 : Double = 0
+        var y0 : Double = 0
+        GEOSCoordSeq_getX_r(GEOS_HANDLE, nearestPointsCoordinateList, 0, &x0)
+        GEOSCoordSeq_getY_r(GEOS_HANDLE, nearestPointsCoordinateList, 0, &y0)
+        
+        var x1 : Double = 0
+        var y1 : Double = 0
+        GEOSCoordSeq_getX_r(GEOS_HANDLE, nearestPointsCoordinateList, 1, &x1)
+        GEOSCoordSeq_getY_r(GEOS_HANDLE, nearestPointsCoordinateList, 1, &y1)
+        
+        return [Coordinate(x: x0, y: y0), Coordinate(x: x1, y: y1)]
+    }
     
     /// - returns: The DE-9IM intersection matrix (a string) representing the topological relationship between this geometry and the other.
     func relationship(_ geometry: Geometry) -> String {

--- a/GEOSwiftTests/GEOSTests.swift
+++ b/GEOSwiftTests/GEOSTests.swift
@@ -97,7 +97,7 @@ class GEOSwiftTests: XCTestCase {
                 result = true
             }
         }
-        
+        XCTAssert(result, "WKT parse failed (expected to receive a MULTIPOINT)")
     }
     
     func testGeoJSON() {
@@ -122,14 +122,10 @@ class GEOSwiftTests: XCTestCase {
         let arrNearestPoints = point.nearestPoints(polygon)
         
         XCTAssertNotNil(arrNearestPoints, "Failed to get nearestPoints array between the two geometries")
-        
-        var result = false
-        if arrNearestPoints[0].x == point.nearestPoint(polygon).x &&
-           arrNearestPoints[0].y == point.nearestPoint(polygon).y  {
-            result = true
-        }
-        
-        XCTAssert(result, "Retro-compatibility of method nearestPoint not respected")
+        XCTAssertEqual(arrNearestPoints.count, 2, "Number of expected points is 2")
+
+        XCTAssertEqual(arrNearestPoints[0].x, point.nearestPoint(polygon).x)
+        XCTAssertEqual(arrNearestPoints[0].y, point.nearestPoint(polygon).y)
         
     }
 }

--- a/GEOSwiftTests/GEOSTests.swift
+++ b/GEOSwiftTests/GEOSTests.swift
@@ -10,7 +10,7 @@ import XCTest
 import GEOSwift
 
 class GEOSwiftTests: XCTestCase {
-    
+
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -20,7 +20,7 @@ class GEOSwiftTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-    
+
     func testCreatePointFromWKT() {
         var result = false
         if let point = Geometry.create("POINT(45 9)") as? Waypoint,
@@ -29,7 +29,7 @@ class GEOSwiftTests: XCTestCase {
         }
         XCTAssert(result, "WKT parse failed (expected to receive a POINT)")
     }
-    
+
     func testCreateLinestringFromWKT() {
         var result = false
         let WKT = "LINESTRING(3 4,10 50,20 25)"
@@ -49,7 +49,7 @@ class GEOSwiftTests: XCTestCase {
         }
         XCTAssert(result, "WKT parse failed (expected to receive a LINEARRING)")
     }
-    
+
     func testCreatePolygonFromWKT() {
         var result = false
         let WKT = "POLYGON((35 10, 45 45, 15 40, 10 20, 35 10),(20 30, 35 35, 30 20, 20 30))"
@@ -73,7 +73,7 @@ class GEOSwiftTests: XCTestCase {
             XCTAssertNotNil(polygon1, "Failed to create polygon from LinearRing")
         }
     }
-    
+
     func testCreateGeometriesCollectionFromWKT() {
         var result = false
         let WKT = "GEOMETRYCOLLECTION(POINT(4 6),LINESTRING(4 6,7 10))"
@@ -87,7 +87,7 @@ class GEOSwiftTests: XCTestCase {
         }
         XCTAssert(result, "WKT parse failed (expected to receive a GEOMETRYCOLLECTION containing a POINT and a LINESTRING)")
     }
-    
+
     func testCreateMultiPointFromWKT() {
         var result = false
         let WKT = "MULTIPOINT(-2 0,-1 -1,0 0,1 -1,2 0,0 2,-2 0)"
@@ -105,7 +105,7 @@ class GEOSwiftTests: XCTestCase {
         if let geojsons = bundle.urls(forResourcesWithExtension: "geojson", subdirectory: nil) {
             for geoJSONURL in geojsons {
                 if let features = try! Features.fromGeoJSON(geoJSONURL)  {
-                    //                    geometries[0].debugQuickLookObject()
+//                    geometries[0].debugQuickLookObject()
                     XCTAssert(true, "GeoJSON correctly parsed")
                     print("\(geoJSONURL.lastPathComponent): \(features)")
                 } else {

--- a/GEOSwiftTests/GEOSTests.swift
+++ b/GEOSwiftTests/GEOSTests.swift
@@ -10,7 +10,7 @@ import XCTest
 import GEOSwift
 
 class GEOSwiftTests: XCTestCase {
-
+    
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -20,7 +20,7 @@ class GEOSwiftTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-
+    
     func testCreatePointFromWKT() {
         var result = false
         if let point = Geometry.create("POINT(45 9)") as? Waypoint,
@@ -29,7 +29,7 @@ class GEOSwiftTests: XCTestCase {
         }
         XCTAssert(result, "WKT parse failed (expected to receive a POINT)")
     }
-
+    
     func testCreateLinestringFromWKT() {
         var result = false
         let WKT = "LINESTRING(3 4,10 50,20 25)"
@@ -49,7 +49,7 @@ class GEOSwiftTests: XCTestCase {
         }
         XCTAssert(result, "WKT parse failed (expected to receive a LINEARRING)")
     }
-
+    
     func testCreatePolygonFromWKT() {
         var result = false
         let WKT = "POLYGON((35 10, 45 45, 15 40, 10 20, 35 10),(20 30, 35 35, 30 20, 20 30))"
@@ -73,7 +73,7 @@ class GEOSwiftTests: XCTestCase {
             XCTAssertNotNil(polygon1, "Failed to create polygon from LinearRing")
         }
     }
-
+    
     func testCreateGeometriesCollectionFromWKT() {
         var result = false
         let WKT = "GEOMETRYCOLLECTION(POINT(4 6),LINESTRING(4 6,7 10))"
@@ -87,7 +87,7 @@ class GEOSwiftTests: XCTestCase {
         }
         XCTAssert(result, "WKT parse failed (expected to receive a GEOMETRYCOLLECTION containing a POINT and a LINESTRING)")
     }
-
+    
     func testCreateMultiPointFromWKT() {
         var result = false
         let WKT = "MULTIPOINT(-2 0,-1 -1,0 0,1 -1,2 0,0 2,-2 0)"
@@ -105,7 +105,7 @@ class GEOSwiftTests: XCTestCase {
         if let geojsons = bundle.urls(forResourcesWithExtension: "geojson", subdirectory: nil) {
             for geoJSONURL in geojsons {
                 if let features = try! Features.fromGeoJSON(geoJSONURL)  {
-//                    geometries[0].debugQuickLookObject()
+                    //                    geometries[0].debugQuickLookObject()
                     XCTAssert(true, "GeoJSON correctly parsed")
                     print("\(geoJSONURL.lastPathComponent): \(features)")
                 } else {

--- a/GEOSwiftTests/GEOSTests.swift
+++ b/GEOSwiftTests/GEOSTests.swift
@@ -97,7 +97,7 @@ class GEOSwiftTests: XCTestCase {
                 result = true
             }
         }
-        XCTAssert(result, "WKT parse failed (expected to receive a MULTIPOINT)")
+        
     }
     
     func testGeoJSON() {
@@ -113,5 +113,23 @@ class GEOSwiftTests: XCTestCase {
                 }
             }
         }
+    }
+    
+    func testNearestPoints() {
+        let point = Geometry.create("POINT(45 9)") as! Waypoint
+        let polygon = Geometry.create("POLYGON((35 10, 45 45, 15 40, 10 20, 35 10),(20 30, 35 35, 30 20, 20 30))") as! Polygon
+        
+        let arrNearestPoints = point.nearestPoints(polygon)
+        
+        XCTAssertNotNil(arrNearestPoints, "Failed to get nearestPoints array between the two geometries")
+        
+        var result = false
+        if arrNearestPoints[0].x == point.nearestPoint(polygon).x &&
+           arrNearestPoints[0].y == point.nearestPoint(polygon).y  {
+            result = true
+        }
+        
+        XCTAssert(result, "Retro-compatibility of method nearestPoint not respected")
+        
     }
 }


### PR DESCRIPTION
Hello,
The nearestPoint method added in PR #18 wasn't appropriate for my use-case, as it returned only the first point of GEOSNearestPoints_r(), which itself is returning an array of points. 

I added a nearestPoints (with a S) method returning an array of Coordinate as specified in this GEOS spec http://geos.refractions.net/ro/doxygen_docs/html/classgeos_1_1operation_1_1distance_1_1DistanceOp.html#a6

To avoid breaking everything, I refactored the nearestPoint (without the S) which use my method. Don't know if it's the best to do, feel free to tell me.