### PR TITLE
Implement Geometry.isEqual(_:)

### DIFF
--- a/GEOSwift/GEOS.swift
+++ b/GEOSwift/GEOS.swift
@@ -155,11 +155,17 @@ public typealias CoordinateDegrees = Double
         return wkt
         
     }()
-}
 
-/// Returns true if the two Geometries are exactly equal.
-public func ==(lhs: Geometry, rhs: Geometry) -> Bool {
-    return GEOSEquals_r(GEOS_HANDLE, lhs.geometry, rhs.geometry) > 0
+    /// Returns true if the two Geometries are exactly equal. This gives Geometry and its
+    /// subclasses an Equatable behavior that is based on the geometry value rather than
+    /// on object identity (the NSObject default). To compare object identity, use ===
+    open override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Geometry else {
+            return false
+        }
+
+        return GEOSEquals_r(GEOS_HANDLE, geometry, other.geometry) > 0
+    }
 }
 
 func GEOSGeomFromWKT(_ handle: GEOSContextHandle_t, WKT: String) -> OpaquePointer? {

--- a/GEOSwiftTests/GEOSTests.swift
+++ b/GEOSwiftTests/GEOSTests.swift
@@ -128,4 +128,66 @@ class GEOSwiftTests: XCTestCase {
         XCTAssertEqual(arrNearestPoints[0].y, point.nearestPoint(polygon).y)
         
     }
+
+    func testIsEqual() {
+        let lhs = LineString(points: [Coordinate(x: 0, y: 0),
+                                      Coordinate(x: 1, y: 0),
+                                      Coordinate(x: 0, y: 1),
+                                      Coordinate(x: 0, y: 0)])!
+
+        // Same instance
+        var rhs: Geometry = lhs
+
+        XCTAssertTrue(lhs == rhs)
+        XCTAssertTrue(rhs == lhs)
+        XCTAssertTrue(lhs.isEqual(rhs))
+        XCTAssertTrue(rhs.isEqual(lhs))
+
+        // Distinct, but equivalent instance
+        rhs = LineString(points: [Coordinate(x: 0, y: 0),
+                                  Coordinate(x: 1, y: 0),
+                                  Coordinate(x: 0, y: 1),
+                                  Coordinate(x: 0, y: 0)])!
+
+        XCTAssertTrue(lhs == rhs)
+        XCTAssertTrue(rhs == lhs)
+        XCTAssertTrue(lhs.isEqual(rhs))
+        XCTAssertTrue(rhs.isEqual(lhs))
+
+        // Non-equivalent instance
+        rhs = LineString(points: [Coordinate(x: 0, y: 0),
+                                  Coordinate(x: 2, y: 0),
+                                  Coordinate(x: 0, y: 2),
+                                  Coordinate(x: 0, y: 0)])!
+
+        XCTAssertFalse(lhs == rhs)
+        XCTAssertFalse(rhs == lhs)
+        XCTAssertFalse(lhs.isEqual(rhs))
+        XCTAssertFalse(rhs.isEqual(lhs))
+
+        // Other type of object
+        XCTAssertFalse(lhs.isEqual(NSObject()))
+
+        // Equivalent subclass
+        rhs = LinearRing(points: [Coordinate(x: 0, y: 0),
+                                  Coordinate(x: 1, y: 0),
+                                  Coordinate(x: 0, y: 1),
+                                  Coordinate(x: 0, y: 0)])!
+
+        XCTAssertTrue(lhs == rhs)
+        XCTAssertTrue(rhs == lhs)
+        XCTAssertTrue(lhs.isEqual(rhs))
+        XCTAssertTrue(rhs.isEqual(lhs))
+
+        // Non-equivalent subclass
+        rhs = LinearRing(points: [Coordinate(x: 0, y: 0),
+                                  Coordinate(x: 2, y: 0),
+                                  Coordinate(x: 0, y: 2),
+                                  Coordinate(x: 0, y: 0)])!
+
+        XCTAssertFalse(lhs == rhs)
+        XCTAssertFalse(rhs == lhs)
+        XCTAssertFalse(lhs.isEqual(rhs))
+        XCTAssertFalse(rhs.isEqual(lhs))
+    }
 }


### PR DESCRIPTION
This gives Geometry and its subclasses an `Equatable` behavior that is based on the geometry value rather than on object identity (the `NSObject` default). To compare object identity, you can still use `===`. This change also improves compatibility with Swift 4.1's new conditional `Equatable` conformances on the standard lib collections by checking value instead of identity if, for example, you compare `[Geometry] == [Geometry]`.