### PR TITLE
Added Envelope geometry

### DIFF
--- a/GEOSwift/MapKit.swift
+++ b/GEOSwift/MapKit.swift
@@ -128,11 +128,11 @@ open class MKShapesCollection : MKShape, MKOverlay  {
         
         self.shapes = shapes
 
-        if let envelope = geometryCollection.envelope() as? Polygon {
-            let exteriorRing = envelope.exteriorRing
-            let upperLeft = MKMapPointForCoordinate(CLLocationCoordinate2DFromCoordinate(exteriorRing.points[2]))
-            let lowerRight = MKMapPointForCoordinate(CLLocationCoordinate2DFromCoordinate(exteriorRing.points[0]))
-            let mapRect = MKMapRectMake(upperLeft.x, upperLeft.y, lowerRight.x - upperLeft.x, lowerRight.y - upperLeft.y)
+        if let envelope = geometryCollection.envelope() {
+            //let exteriorRing = envelope.exteriorRing
+            let bottomLeft = MKMapPointForCoordinate(CLLocationCoordinate2DFromCoordinate(envelope.bottomLeft))
+            let topRight = MKMapPointForCoordinate(CLLocationCoordinate2DFromCoordinate(envelope.topRight))
+            let mapRect = MKMapRectMake(bottomLeft.x, bottomLeft.y, topRight.x - bottomLeft.x, topRight.y - bottomLeft.y)
             self.boundingMapRect = mapRect
             
         } else {

--- a/GEOSwift/SpatialAnalysis.swift
+++ b/GEOSwift/SpatialAnalysis.swift
@@ -67,11 +67,11 @@ public extension Geometry {
     }
     
     /// - returns: A Polygon that represents the bounding envelope of this geometry.
-    func envelope() -> Geometry? {
+    func envelope() -> Envelope? {
         guard let envelopeGEOM = GEOSEnvelope_r(GEOS_HANDLE, self.geometry) else {
             return nil
         }
-        return Geometry.create(envelopeGEOM, destroyOnDeinit: true) 
+        return Envelope(GEOSGeom: envelopeGEOM, destroyOnDeinit: true)
     }
     
     /// - returns: A POINT guaranteed to lie on the surface.

--- a/GEOSwiftTests/GEOSTests.swift
+++ b/GEOSwiftTests/GEOSTests.swift
@@ -74,6 +74,21 @@ class GEOSwiftTests: XCTestCase {
         }
     }
 
+    func testCreateEnvelopeFromCoordinates() {
+        let env = Envelope(p1: Coordinate(x:-10, y:10), p2: Coordinate(x:10, y:-10))
+        XCTAssertNotNil(env, "Failed to create Envelope")
+        let geom = env!.envelope()
+        XCTAssertEqual(env, geom)
+    }
+    
+    func testCreateEnvelopeByExpanding() {
+        let env = Envelope(p1: Coordinate(x:-10, y:10), p2: Coordinate(x:10, y:-10))
+        XCTAssertNotNil(env, "Failed to create Envelope")
+        let newEnv = Envelope.byExpanding(env!, toInclude: Waypoint(latitude: 11, longitude: 11)!)
+        XCTAssertNotNil(env, "Failed to expand Envelope")
+        XCTAssertEqual(newEnv!,  Envelope(p1: Coordinate(x:-10, y:11), p2: Coordinate(x:11, y:-10))!)
+    }
+    
     func testCreateGeometriesCollectionFromWKT() {
         var result = false
         let WKT = "GEOMETRYCOLLECTION(POINT(4 6),LINESTRING(4 6,7 10))"


### PR DESCRIPTION
JTS & geos both expose an Envelope via `getEnvelopeInternal()`, but this is not available in the c api. There’s value in being able to extract the bounding box for a geometry, but `getEnvelope()` makes this difficult/error-prone.

I’ve added `Envelope` as a subclass of Polygon, which isn’t consistent with the other libs, but is the simplest solution available, plus has the added benefit of being a non-breaking change.

There’s something wonky with that MapKit `MKMapRect` conversion, it looks like the points were the opposite to what they should be (unless I’m misunderstanding how it should work). I tried to test this in the playground but I was having issues. Let me know if you’d prefer me to spin up a new project & double-check the changed logic seems to work.