### PR TITLE
Parse "id" of Feature to comply with GeoJSON spec. section 3.2 (RFC 7946)

### DIFF
--- a/GEOSwift/Feature.swift
+++ b/GEOSwift/Feature.swift
@@ -13,6 +13,7 @@ import Foundation
  */
 public class Feature {
     
+    public var id: Any?
     public var geometries: Array<Geometry>?
     public var properties: NSDictionary?
     

--- a/GEOSwift/GeoJSON.swift
+++ b/GEOSwift/GeoJSON.swift
@@ -147,12 +147,14 @@ private func ParseGEOJSONFeatureCollection(_ features: NSArray) -> [Feature]? {
 
 private func ParseGEOJSONFeature(_ GEOJSONFeature: Dictionary<String, AnyObject>) -> Feature? {
     // map feature representaion to Feature Object with properties and GEOS geometry
+    let id = GEOJSONFeature["id"]
     if let geometry = GEOJSONFeature["geometry"] as? Dictionary<String,AnyObject>,
         let properties = GEOJSONFeature["properties"] as? NSDictionary,
         let geometryType = geometry["type"] as? String,
         let geometryCoordinates = geometry["coordinates"] as? NSArray,
         let geometryObject = ParseGEOJSONGeometry(geometryType, coordinatesNSArray: geometryCoordinates) {
             let feature = Feature()
+            feature.id = id
             feature.geometries?.append(geometryObject)
             feature.properties = properties
             return feature

--- a/GEOSwiftTests/feature.geojson
+++ b/GEOSwiftTests/feature.geojson
@@ -1,5 +1,6 @@
 {
     "type": "Feature",
+    "id": "f1",
     "geometry": {
         "type": "Polygon",
         "coordinates": [

--- a/GEOSwiftTests/featurecollection.geojson
+++ b/GEOSwiftTests/featurecollection.geojson
@@ -3,6 +3,7 @@
     "features": [
         {
             "type": "Feature",
+            "id": "f1",
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -17,6 +18,7 @@
         },
         {
             "type": "Feature",
+            "id": 2,
             "geometry": {
                 "type": "Point",
                 "coordinates": [
@@ -45,6 +47,7 @@
         },
         {
             "type": "Feature",
+            "id": "f2",
             "geometry": {
                 "type": "Point",
                 "coordinates": [


### PR DESCRIPTION
Fixes issue #96