### PR TITLE
Fix deprecated function calls

### DIFF
--- a/GEOSwift/GeoJSON.swift
+++ b/GEOSwift/GeoJSON.swift
@@ -337,7 +337,7 @@ private func GEOJSONCreatePolygonFromRepresentation(_ representation: NSArray) -
     }
 
     // Polygons with multiple rings
-    var rings: Array<LinearRing> = ringsCoords.flatMap({
+    var rings: Array<LinearRing> = ringsCoords.compactMap({
         (ringCoords: [[Double]]) -> LinearRing? in
         if let sequence = GEOJSONSequenceFromArrayRepresentation(ringCoords),
             let GEOSGeom = GEOSGeom_createLinearRing_r(GEOS_HANDLE, sequence) {

--- a/GEOSwift/Geometries.swift
+++ b/GEOSwift/Geometries.swift
@@ -101,7 +101,7 @@ open class Polygon : Geometry {
         }
         defer {
             if let holes = holes, holes.count > 0 {
-                geometriesPointer?.deallocate(capacity: holes.count)
+                geometriesPointer?.deallocate()
             }
         }
         guard let geometry = GEOSGeom_createPolygon_r(GEOS_HANDLE, shellGEOSGeom, geometriesPointer, UInt32(holes?.count ?? 0)) else {
@@ -170,7 +170,7 @@ open class GeometryCollection<T: Geometry> : Geometry {
      */
     public convenience init?(geometries: [T]) {
         let geometriesPointer = UnsafeMutablePointer<OpaquePointer?>.allocate(capacity: geometries.count)
-        defer { geometriesPointer.deallocate(capacity: geometries.count) }
+        defer { geometriesPointer.deallocate() }
         for (i, geom) in geometries.enumerated() {
             let GEOSGeom = GEOSGeom_clone_r(GEOS_HANDLE, geom.geometry)
             geometriesPointer[i] = GEOSGeom
@@ -194,7 +194,7 @@ open class MultiLineString<T: LineString> : GeometryCollection<T> {
 
     public convenience init?(linestrings: [T]) {
         let geometriesPointer = UnsafeMutablePointer<OpaquePointer?>.allocate(capacity: linestrings.count)
-        defer { geometriesPointer.deallocate(capacity: linestrings.count) }
+        defer { geometriesPointer.deallocate() }
         for (i, geom) in linestrings.enumerated() {
             let GEOSGeom = GEOSGeom_clone_r(GEOS_HANDLE, geom.geometry)
             geometriesPointer[i] = GEOSGeom
@@ -216,7 +216,7 @@ open class MultiPoint<T: Waypoint> : GeometryCollection<T> {
     }
     public convenience init?(points: [T]) {
         let coordsPointer = UnsafeMutablePointer<OpaquePointer?>.allocate(capacity: points.count)
-        defer { coordsPointer.deallocate(capacity: points.count) }
+        defer { coordsPointer.deallocate() }
         for (i, geom) in points.enumerated() {
             let GEOSGeom = GEOSGeom_clone_r(GEOS_HANDLE, geom.geometry)
             coordsPointer[i] = GEOSGeom
@@ -239,7 +239,7 @@ open class MultiPolygon<T: Polygon> : GeometryCollection<T> {
     }
     public convenience init?(polygons: [T]) {
         let coordsPointer = UnsafeMutablePointer<OpaquePointer?>.allocate(capacity: polygons.count)
-        defer { coordsPointer.deallocate(capacity: polygons.count) }
+        defer { coordsPointer.deallocate() }
         for (i, geom) in polygons.enumerated() {
             let GEOSGeom = GEOSGeom_clone_r(GEOS_HANDLE, geom.geometry)
             coordsPointer[i] = GEOSGeom


### PR DESCRIPTION
I believe this should fix #89.

This PR silences compile warnings by replacing calls to the deprecated Swift functions `flatMap` and `deallocate(capacity: Int)` with more current versions of those functions.