### PR TITLE
Fix Codecov integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ language: objective-c
 
 before_install:
   - gem install xcpretty
-  - gem install cocoapods -v '1.5.0'
+  - gem install cocoapods -v '1.5.3'
   - pod repo update
   - pod install --verbose
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - bash <(curl -s https://codecov.io/bash) -J '^GEOSwift$'
 
-osx_image: xcode9.3
+osx_image: xcode9.4
 
 cache: cocoapods
 
@@ -17,15 +17,12 @@ env:
   global:
     - WORKSPACE=GEOSwift.xcworkspace
     - SCHEME=GEOSwift
-    - SDK=iphonesimulator11.3
+    - SDK=iphonesimulator11.4
   matrix:
-    - DESTINATION="OS=11.3,name=iPhone X"
+    - DESTINATION="OS=11.4,name=iPhone X"
 
 script:
   - set -o pipefail
-  - xcodebuild -version
-  - xcodebuild -showsdks
-
   - xcodebuild
     -workspace "$WORKSPACE"
     -scheme "$SCHEME"
@@ -33,14 +30,4 @@ script:
     -destination "$DESTINATION"
     -configuration Debug
     ONLY_ACTIVE_ARCH=YES
-    clean test | xcpretty -c;
-
-  - xcodebuild
-    -workspace "$WORKSPACE"
-    -scheme "$SCHEME"
-    -sdk "$SDK"
-    -destination "$DESTINATION"
-    -configuration Release
-    ONLY_ACTIVE_ARCH=YES
-    ENABLE_TESTABILITY=YES
     clean test | xcpretty -c;

--- a/GEOSwift.xcodeproj/xcshareddata/xcschemes/GEOSwift.xcscheme
+++ b/GEOSwift.xcodeproj/xcshareddata/xcschemes/GEOSwift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0920"
+   LastUpgradeVersion = "0940"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
-# Uncomment this line to define a global platform for your project
 platform :ios, '8.0'
 
 use_frameworks!
+inhibit_all_warnings!
 
 target 'GEOSwift' do
   pod 'geos'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,12 +5,12 @@ DEPENDENCIES:
   - geos
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  https://github.com/cocoapods/specs.git:
     - geos
 
 SPEC CHECKSUMS:
   geos: e96c6ca3f3ce02d20feaa8d90d4af383e11e7198
 
-PODFILE CHECKSUM: 51ad745c42216871e2c10593cc83e062c0f56204
+PODFILE CHECKSUM: 2a3756bb1bc6ab3e2030d2f45562c86ee3f64840
 
-COCOAPODS: 1.5.0
+COCOAPODS: 1.5.3


### PR DESCRIPTION
Codecov is not working if CI does a Release build. This commit updates the CI config so that it will only do a Debug build. It also updates the versions of cocoapods and Xcode to use. Additionally, we now use the Codecov -J option so that coverage is only reported for the framework sources, not for the test sources. Lastly, we now inhibit geos warnings to shorten build logs and reduce the warning noise when developing GEOSwift.

Note that the relative coverage for this PR will seem drastically reduced, but it's actually a meaningless comparison between coverage in GEOSwiftTests and GEOSwift. We only care about GEOSwift coverage, which is what will be reported from now on.