### PR TITLE
Add swiftlint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,12 @@
+included: # paths to include during linting. `--path` is ignored if present.
+  - GEOSwift
+  - GEOSwiftTests
+disabled_rules:
+  - force_cast
+  - identifier_name
+opt_in_rules:
+  - closure_spacing
+  - empty_count
+  - implicit_return
+  - pattern_matching_keywords
+  - vertical_parameter_alignment_on_call

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_install:
   - gem install cocoapods -v '1.5.3'
   - pod repo update
   - pod install --verbose
+  - brew install swiftlint
 
 after_success:
   - bash <(curl -s https://codecov.io/bash) -J '^GEOSwift$'

--- a/GEOSwift.playground/Contents.swift
+++ b/GEOSwift.playground/Contents.swift
@@ -76,8 +76,7 @@ geometry2
 //:
 if let geoJSONURL = Bundle.main.url(forResource: "multipolygon", withExtension: "geojson"),
     let features = try! Features.fromGeoJSON(geoJSONURL),
-    let italy = features.first?.geometries?.first as? MultiPolygon
-{
+    let italy = features.first?.geometries?.first as? MultiPolygon {
     italy
 
 //: ### Topological operations:
@@ -92,7 +91,7 @@ if let geoJSONURL = Bundle.main.url(forResource: "multipolygon", withExtension: 
     italy.intersection(geometry2!)
     italy.difference(geometry2!)
     italy.union(geometry2!)
-    
+
 //: ### Predicates:
 //: 
     italy.disjoint(geometry2!)

--- a/GEOSwift.playground/Sources/SupportCode.swift
+++ b/GEOSwift.playground/Sources/SupportCode.swift
@@ -4,14 +4,13 @@
 
 import Foundation
 
-
 extension NSData {
     public class func fromHexString (string: String) -> NSData {
         // Based on: http://stackoverflow.com/a/2505561/313633
         let data = NSMutableData()
-        
+
         var temp = ""
-        
+
         for char in string.characters {
             temp+=String(char)
             if(temp.characters.count == 2) {

--- a/GEOSwift.xcodeproj/project.pbxproj
+++ b/GEOSwift.xcodeproj/project.pbxproj
@@ -243,6 +243,7 @@
 			buildConfigurationList = CD22999D1B10B506002C19AE /* Build configuration list for PBXNativeTarget "GEOSwift" */;
 			buildPhases = (
 				62A7A265A251663EAA88D507 /* [CP] Check Pods Manifest.lock */,
+				839350CC20EFFA3300403B56 /* Swiftlint */,
 				CD22997F1B10B506002C19AE /* Sources */,
 				CD2299811B10B506002C19AE /* Headers */,
 				CD2299821B10B506002C19AE /* Resources */,
@@ -382,6 +383,20 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
+		};
+		839350CC20EFFA3300403B56 /* Swiftlint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = Swiftlint;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint > /dev/null; then\n  swiftlint autocorrect\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
 		};
 		DE7797CE079BC339662037BC /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/GEOSwift/Feature.swift
+++ b/GEOSwift/Feature.swift
@@ -12,12 +12,12 @@ import Foundation
  * Represent a feature object containing geometries and properties object according to GEOJson specification
  */
 public class Feature {
-    
+
     public var id: Any?
-    public var geometries: Array<Geometry>?
+    public var geometries: [Geometry]?
     public var properties: NSDictionary?
-    
+
     init() {
-        geometries = Array<Geometry>()
+        geometries = [Geometry]()
     }
 }

--- a/GEOSwift/GEOS.swift
+++ b/GEOSwift/GEOS.swift
@@ -205,7 +205,7 @@ public struct CoordinatesCollection: Collection {
     }
 
     public var endIndex: UInt32 {
-        return count - 1
+        return count
     }
 
     public func index(after i: UInt32) -> UInt32 {

--- a/GEOSwift/GEOS.swift
+++ b/GEOSwift/GEOS.swift
@@ -9,7 +9,7 @@ import Foundation
 
 typealias GEOSCallbackFunction = @convention(c) (UnsafeMutableRawPointer) -> Void
 
-let swiftCallback : GEOSCallbackFunction = {
+let swiftCallback: GEOSCallbackFunction = {
     guard let string = String(validatingUTF8: $0.assumingMemoryBound(to: CChar.self)) else { return }
     print("GEOSwift # " + string + ".")
 }
@@ -38,13 +38,13 @@ final public class GeometryStorage {
 
     deinit {
         if parent == nil {
-            GEOSGeom_destroy_r(GEOS_HANDLE, GEOSGeom);
+            GEOSGeom_destroy_r(GEOS_HANDLE, GEOSGeom)
         }
     }
 }
 
 /// A base abstract geometry class
-// Geometry is a model data type, so a struct would be a better fit, but it is actually a wrapper of GEOS native objects,
+// Geometry is a model data type, so a struct would be a better fit, but it is actually a wrapper of GEOS native objects
 // that are in fact C pointers, and structs in Swift don't have a dealloc where one can release allocated memory.
 // Furthermore, being a class Geometry can inherit from NSObject so that debugQuickLookObject() can be implemented
 open class Geometry: NSObject {
@@ -89,34 +89,34 @@ open class Geometry: NSObject {
         switch UInt32(geometryTypeId) {
         case GEOS_POINT.rawValue:
             subclass = Waypoint.self
-            
+
         case GEOS_LINESTRING.rawValue:
             subclass = LineString.self
-            
+
         case GEOS_LINEARRING.rawValue:
             subclass = LinearRing.self
-            
+
         case GEOS_POLYGON.rawValue:
             subclass = Polygon.self
-            
+
         case GEOS_MULTIPOINT.rawValue:
             subclass = MultiPoint.self
-            
+
         case GEOS_MULTILINESTRING.rawValue:
             subclass = MultiLineString.self
-            
+
         case GEOS_MULTIPOLYGON.rawValue:
             subclass = MultiPolygon.self
-            
+
         case GEOS_GEOMETRYCOLLECTION.rawValue:
             subclass = GeometryCollection<Geometry>.self
-            
+
         default:
             return nil
         }
         return subclass
     }
-    
+
     /**
      Create a Geometry subclass from its Well Known Text representation.
 
@@ -141,7 +141,7 @@ open class Geometry: NSObject {
 
      - returns: The proper Geometry subclass as parsed from the binary data (i.e. `Waypoint`).
      */
-    open class func create(_ WKB: UnsafePointer<UInt8>, size: Int)  -> Geometry? {
+    open class func create(_ WKB: UnsafePointer<UInt8>, size: Int) -> Geometry? {
         let WKBReader = GEOSWKBReader_create_r(GEOS_HANDLE)
         defer { GEOSWKBReader_destroy_r(GEOS_HANDLE, WKBReader) }
         guard let GEOSGeom = GEOSWKBReader_read_r(GEOS_HANDLE, WKBReader, WKB, size) else {
@@ -151,7 +151,7 @@ open class Geometry: NSObject {
     }
 
     /// The Well Known Text (WKT) representation of the Geometry.
-    fileprivate(set) open lazy var WKT : String? = {
+    fileprivate(set) open lazy var WKT: String? = {
         let WKTWriter = GEOSWKTWriter_create_r(GEOS_HANDLE)
         GEOSWKTWriter_setTrim_r(GEOS_HANDLE, WKTWriter, 1)
         guard let wktString = GEOSWKTWriter_write_r(GEOS_HANDLE, WKTWriter, storage.GEOSGeom) else {
@@ -164,7 +164,7 @@ open class Geometry: NSObject {
     }()
 
     /// The Well Known Binary (WKB) representation of the Geometry.
-    fileprivate(set) open lazy var WKB : [UInt8]? = {
+    fileprivate(set) open lazy var WKB: [UInt8]? = {
         let WKBWriter = GEOSWKBWriter_create_r(GEOS_HANDLE)
         var size: Int = 0
         guard let buf = GEOSWKBWriter_write_r(GEOS_HANDLE, WKBWriter, storage.GEOSGeom, &size), size > 0 else {
@@ -175,7 +175,7 @@ open class Geometry: NSObject {
         GEOSWKBWriter_destroy_r(GEOS_HANDLE, WKBWriter)
         return wkb
     }()
-    
+
     /// Returns true if the two Geometries are exactly equal. This gives Geometry and its
     /// subclasses an Equatable behavior that is based on the geometry value rather than
     /// on object identity (the NSObject default). To compare object identity, use ===
@@ -188,30 +188,42 @@ open class Geometry: NSObject {
     }
 }
 
-public struct CoordinatesCollection: Sequence {
+public struct CoordinatesCollection: Collection {
     private let storage: GeometryStorage
     public let count: UInt32
-    
+
     init(storage: GeometryStorage) {
         self.storage = storage
         let sequence = GEOSGeom_getCoordSeq_r(GEOS_HANDLE, storage.GEOSGeom)
         var numCoordinates: UInt32 = 0
-        GEOSCoordSeq_getSize_r(GEOS_HANDLE, sequence, &numCoordinates);
+        GEOSCoordSeq_getSize_r(GEOS_HANDLE, sequence, &numCoordinates)
         self.count = numCoordinates
     }
-    
+
+    public var startIndex: UInt32 {
+        return 0
+    }
+
+    public var endIndex: UInt32 {
+        return count - 1
+    }
+
+    public func index(after i: UInt32) -> UInt32 {
+        return i + 1
+    }
+
     public subscript(index: UInt32) -> Coordinate {
         var x: Double = 0
         var y: Double = 0
 
         assert(self.count > index, "Index out of bounds")
         let sequence = GEOSGeom_getCoordSeq_r(GEOS_HANDLE, storage.GEOSGeom)
-        GEOSCoordSeq_getX_r(GEOS_HANDLE, sequence, index, &x);
-        GEOSCoordSeq_getY_r(GEOS_HANDLE, sequence, index, &y);
+        GEOSCoordSeq_getX_r(GEOS_HANDLE, sequence, index, &x)
+        GEOSCoordSeq_getY_r(GEOS_HANDLE, sequence, index, &y)
 
         return Coordinate(x: x, y: y)
     }
-    
+
     public func makeIterator() -> AnyIterator<Coordinate> {
         var index: UInt32 = 0
         return AnyIterator {
@@ -221,9 +233,9 @@ public struct CoordinatesCollection: Sequence {
             return item
         }
     }
-    
+
     public func map<U>(_ transform: (Coordinate) -> U) -> [U] {
-        var array = Array<U>()
+        var array = [U]()
         for coord in self {
             array.append(transform(coord))
         }
@@ -257,7 +269,7 @@ public struct GeometriesCollection<T: Geometry>: Sequence {
     }
 
     public func map<U>(_ transform: (T) -> U) -> [U] {
-        var array = Array<U>()
+        var array = [U]()
         for geom in self {
             array.append(transform(geom))
         }

--- a/GEOSwift/GeoJSON.swift
+++ b/GEOSwift/GeoJSON.swift
@@ -15,12 +15,12 @@ public enum GEOJSONParseError: Error {
 public extension Geometry {
 
     @available(*, deprecated: 2.1.0, renamed: "Features.fromGeoJSON(_:)")
-    public class func fromGeoJSON(_ URL: Foundation.URL) throws -> Array<Geometry>? {
+    public class func fromGeoJSON(_ URL: Foundation.URL) throws -> [Geometry]? {
         return try Features.fromGeoJSON(URL)?.first?.geometries
     }
 
     @available(*, deprecated: 2.1.0, renamed: "Features.fromGeoJSONDictionary(_:)")
-    public class func fromGeoJSONDictionary(_ dictionary: Dictionary<String, AnyObject>) -> Array<Geometry>? {
+    public class func fromGeoJSONDictionary(_ dictionary: [String: AnyObject]) -> [Geometry]? {
         return Features.fromGeoJSONDictionary(dictionary)?.first?.geometries
     }
 
@@ -41,7 +41,7 @@ public extension Array where Element == Feature {
         }
         return try fromGeoJSON(JSONData)
     }
-        
+
     /**
      Creates an `Array` of `Geometry` instances from a GeoJSON string.
      
@@ -55,7 +55,7 @@ public extension Array where Element == Feature {
         }
         return try fromGeoJSON(data)
     }
-    
+
     /**
      Creates an `Array` of `Geometry` instances from GeoJSON data.
      
@@ -66,11 +66,12 @@ public extension Array where Element == Feature {
     public static func fromGeoJSON(_ data: Data) throws -> Features? {
         do {
             // read JSON file
-            let parsedObject = try JSONSerialization.jsonObject(with: data,
-                                                                options: JSONSerialization.ReadingOptions.allowFragments) as? NSDictionary
-            
+            let parsedObject = try JSONSerialization.jsonObject(
+                with: data,
+                options: JSONSerialization.ReadingOptions.allowFragments) as? NSDictionary
+
             // is the root a Dictionary with a "type" key of value "FeatureCollection"?
-            if let rootObject = parsedObject as? Dictionary<String, AnyObject> {
+            if let rootObject = parsedObject as? [String: AnyObject] {
                 return fromGeoJSONDictionary(rootObject)
             } else {
                 throw GEOJSONParseError.invalidGEOJSON
@@ -79,7 +80,7 @@ public extension Array where Element == Feature {
             throw GEOJSONParseError.invalidJSON
         }
     }
-    
+
     /**
     Creates an `Array` of `Feature` instances from a GeoJSON dictionary.
     
@@ -87,40 +88,39 @@ public extension Array where Element == Feature {
     
     :returns: An optional `Array` of `Feature` instances.
     */
-    public static func fromGeoJSONDictionary(_ dictionary: Dictionary<String, AnyObject>) -> Features? {
+    public static func fromGeoJSONDictionary(_ dictionary: [String: AnyObject]) -> Features? {
         return ParseGEOJSONObject(dictionary)
     }
 }
 
 // MARK: - Private parsing functions
 
-private func ParseGEOJSONObject(_ GEOJSONObject: Dictionary<String, AnyObject>) -> Features? {
-    
+private func ParseGEOJSONObject(_ GEOJSONObject: [String: AnyObject]) -> Features? {
+
     if let type = GEOJSONObject["type"] as? String {
-        
+
         // is there a "features" key of type NSArray?
-        switch (type) {
+        switch type {
         case "Feature":
             if let feature = ParseGEOJSONFeature(GEOJSONObject) {
                 return [feature]
             }
-            
+
         case "FeatureCollection":
             if let featureCollection = GEOJSONObject["features"] as? NSArray {
                 return ParseGEOJSONFeatureCollection(featureCollection)
             }
-            
+
         case "GeometryCollection":
             if let geometryCollection = GEOJSONObject["geometries"] as? NSArray {
                 let feature = Feature()
                 feature.geometries = ParseGEOJSONGeometryCollection(geometryCollection)
                 return [feature]
             }
-            
+
         default:
             if let coordinates = GEOJSONObject["coordinates"] as? NSArray,
-                let geometry = ParseGEOJSONGeometry(type, coordinatesNSArray: coordinates)
-            {
+                let geometry = ParseGEOJSONGeometry(type, coordinatesNSArray: coordinates) {
                 let feature = Feature()
                 feature.geometries?.append(geometry)
                 return [feature]
@@ -135,7 +135,7 @@ private func ParseGEOJSONFeatureCollection(_ features: NSArray) -> [Feature]? {
     var featuresArray = Features()
     for feature in features {
         if let feat1 = feature as? NSDictionary,
-            let feat2 = feat1 as? Dictionary<String,AnyObject>,
+            let feat2 = feat1 as? [String: AnyObject],
             let featureObject = ParseGEOJSONFeature(feat2) {
                 featuresArray.append(featureObject)
         } else {
@@ -145,10 +145,10 @@ private func ParseGEOJSONFeatureCollection(_ features: NSArray) -> [Feature]? {
     return featuresArray
 }
 
-private func ParseGEOJSONFeature(_ GEOJSONFeature: Dictionary<String, AnyObject>) -> Feature? {
+private func ParseGEOJSONFeature(_ GEOJSONFeature: [String: AnyObject]) -> Feature? {
     // map feature representaion to Feature Object with properties and GEOS geometry
     let id = GEOJSONFeature["id"]
-    if let geometry = GEOJSONFeature["geometry"] as? Dictionary<String,AnyObject>,
+    if let geometry = GEOJSONFeature["geometry"] as? [String: AnyObject],
         let properties = GEOJSONFeature["properties"] as? NSDictionary,
         let geometryType = geometry["type"] as? String,
         let geometryCoordinates = geometry["coordinates"] as? NSArray,
@@ -164,10 +164,10 @@ private func ParseGEOJSONFeature(_ GEOJSONFeature: Dictionary<String, AnyObject>
 
 private func ParseGEOJSONGeometryCollection(_ geometries: NSArray) -> [Geometry]? {
     // map every geometry representation to a GEOS geometry
-    var GEOSGeometries = Array<Geometry>()
+    var GEOSGeometries = [Geometry]()
     for geometry in geometries {
         if let geom1 = geometry as? NSDictionary,
-            let geom2 = geom1 as? Dictionary<String,AnyObject>,
+            let geom2 = geom1 as? [String: AnyObject],
             let geomType = geom2["type"] as? String,
             let geomCoordinates = geom2["coordinates"] as? NSArray,
             let geom = ParseGEOJSONGeometry(geomType, coordinatesNSArray: geomCoordinates) {
@@ -179,6 +179,7 @@ private func ParseGEOJSONGeometryCollection(_ geometries: NSArray) -> [Geometry]
     return GEOSGeometries
 }
 
+// swiftlint:disable:next cyclomatic_complexity function_body_length
 private func ParseGEOJSONGeometry(_ type: String, coordinatesNSArray: NSArray) -> Geometry? {
     switch type {
     case "Point":
@@ -189,13 +190,13 @@ private func ParseGEOJSONGeometry(_ type: String, coordinatesNSArray: NSArray) -
                 return nil
         }
         return Waypoint(storage: GeometryStorage(GEOSGeom: GEOSGeom, parent: nil))
-        
+
     case "MultiPoint":
         // For type "MultiPoint", the "coordinates" member must be an array of positions.
         guard let coordinatesNSArray = coordinatesNSArray as? [[Double]] else {
             return nil
         }
-        var pointArray = Array<Waypoint>()
+        var pointArray = [Waypoint]()
         for singlePointCoordinates in coordinatesNSArray {
             guard let sequence = GEOJSONSequenceFromArrayRepresentation([singlePointCoordinates]),
                 let GEOSGeom = GEOSGeom_createPoint_r(GEOS_HANDLE, sequence) else {
@@ -205,7 +206,7 @@ private func ParseGEOJSONGeometry(_ type: String, coordinatesNSArray: NSArray) -
             pointArray.append(point)
         }
         return MultiPoint(points: pointArray)
-        
+
     case "LineString":
         // For type "LineString", the "coordinates" member must be an array of two or more positions.
         guard let coordinates = coordinatesNSArray as? [[Double]],
@@ -214,13 +215,13 @@ private func ParseGEOJSONGeometry(_ type: String, coordinatesNSArray: NSArray) -
                 return nil
         }
         return LineString(storage: GeometryStorage(GEOSGeom: GEOSGeom, parent: nil))
-        
+
     case "MultiLineString":
         // For type "MultiLineString", the "coordinates" member must be an array of LineString coordinate arrays.
         guard let linestringsRepresentation = coordinatesNSArray as? [[[Double]]] else {
             return nil
         }
-        var linestrings: Array<LineString> = []
+        var linestrings: [LineString] = []
         for coordinates in linestringsRepresentation {
             guard let sequence = GEOJSONSequenceFromArrayRepresentation(coordinates),
                 let GEOSGeom = GEOSGeom_createLineString_r(GEOS_HANDLE, sequence) else {
@@ -233,68 +234,62 @@ private func ParseGEOJSONGeometry(_ type: String, coordinatesNSArray: NSArray) -
 
     case "Polygon":
         return GEOJSONCreatePolygonFromRepresentation(coordinatesNSArray)
-        
+
     case "MultiPolygon":
         // For type "MultiPolygon", the "coordinates" member must be an array of Polygon coordinate arrays.
-        var polygons = Array<Polygon>()
+        var polygons = [Polygon]()
         for representation in coordinatesNSArray {
             guard let polyRepresentation = representation as? NSArray,
                   let geom = GEOJSONCreatePolygonFromRepresentation(polyRepresentation) else {
                 return nil
             }
-            
+
             polygons.append(geom)
         }
         return MultiPolygon(polygons: polygons)
-    
+
     default:
         return nil
     }
 }
 
-// MARK:
+// MARK: 
 
-private func GEOJSONGeometryFromDictionaryRepresentation(_ dictionary: Dictionary<String,AnyObject>) -> Geometry? {
+private func GEOJSONGeometryFromDictionaryRepresentation(_ dictionary: [String: AnyObject]) -> Geometry? {
 
-    if  let geometryDict = dictionary["geometry"] as? Dictionary<String,AnyObject>,
+    if  let geometryDict = dictionary["geometry"] as? [String: AnyObject],
         let geometryType = geometryDict["type"] as? String {
-            
-            switch geometryType {
-                
-                case "GeometryCollection":
-                    // A GeoJSON object with type "GeometryCollection" is a geometry object which represents a collection of geometry objects.
-                    // A geometry collection must have a member with the name "geometries". The value corresponding to "geometries" is an array. Each element in this array is a GeoJSON geometry object.
-                    
-                    if let geometriesNSArray = geometryDict["geometries"] as? NSArray,
-                        let geometriesArray = geometriesNSArray as? Array<NSDictionary> {
-                            
-                        var geometries = Array<Geometry>()
-                        for geometryNSDictionary in geometriesArray {
-                            if let geometryType = geometryNSDictionary["type"] as? String,
-                                let coordinatesNSArray = geometryNSDictionary["coordinates"] as? NSArray,
-                                let geometry = ParseGEOJSONGeometry(geometryType, coordinatesNSArray: coordinatesNSArray) {
-                                    geometries.append(geometry)
-                            } else {
-                                return nil
-                            }
-                        }
-                        return GeometryCollection(geometries: geometries)
+
+        switch geometryType {
+        case "GeometryCollection":
+            // A geometry collection must have a "geometries" member, which is an array of GeoJSON geometry objects.
+            if let geometriesNSArray = geometryDict["geometries"] as? NSArray,
+                let geometriesArray = geometriesNSArray as? [NSDictionary] {
+                var geometries = [Geometry]()
+                for geometryNSDictionary in geometriesArray {
+                    if let geometryType = geometryNSDictionary["type"] as? String,
+                        let coordinatesNSArray = geometryNSDictionary["coordinates"] as? NSArray,
+                        let geometry = ParseGEOJSONGeometry(geometryType, coordinatesNSArray: coordinatesNSArray) {
+                        geometries.append(geometry)
+                    } else {
+                        return nil
+                    }
                 }
-                
-                default:
-                    if let coordinatesNSArray = geometryDict["coordinates"] as? NSArray {
-                        return ParseGEOJSONGeometry(geometryType, coordinatesNSArray: coordinatesNSArray)
-                }
+                return GeometryCollection(geometries: geometries)
             }
-            
+        default:
+            if let coordinatesNSArray = geometryDict["coordinates"] as? NSArray {
+                return ParseGEOJSONGeometry(geometryType, coordinatesNSArray: coordinatesNSArray)
+            }
+        }
+
     }
     return nil
 }
 
 private func GEOJSONCoordinatesFromArrayRepresentation(_ array: [[Double]]) -> [Coordinate]? {
-    return array.map {
-        coordinatePair in
-        return Coordinate(x: coordinatePair[0], y: coordinatePair[1])
+    return array.map { coordinatePair in
+        Coordinate(x: coordinatePair[0], y: coordinatePair[1])
     }
 }
 
@@ -321,9 +316,11 @@ private func GEOJSONCreateLinearRingFromRepresentation(_ representation: [[Doubl
 }
 
 private func GEOJSONCreatePolygonFromRepresentation(_ representation: NSArray) -> Polygon? {
-    
-    // For type "Polygon", the "coordinates" member must be an array of LinearRing coordinate arrays. For Polygons with multiple rings, the first must be the exterior ring and any others must be interior rings or holes.
-    
+
+    // For type "Polygon", the "coordinates" member must be an array of LinearRing coordinate arrays.
+    // For Polygons with multiple rings, the first must be the exterior ring and any others must be
+    // interior rings or holes.
+
     if let coordinates = representation as? [[Double]] {
         // array of LinearRing coordinate arrays
         guard let shell = GEOJSONCreateLinearRingFromRepresentation(coordinates) else {
@@ -333,14 +330,12 @@ private func GEOJSONCreatePolygonFromRepresentation(_ representation: NSArray) -
         return polygon
     }
 
-    guard let ringsCoords = representation as? [[[Double]]],
-        ringsCoords.count > 0 else {
-            return nil
+    guard let ringsCoords = representation as? [[[Double]]], !ringsCoords.isEmpty else {
+        return nil
     }
 
     // Polygons with multiple rings
-    var rings: Array<LinearRing> = ringsCoords.compactMap({
-        (ringCoords: [[Double]]) -> LinearRing? in
+    var rings = ringsCoords.compactMap { (ringCoords) -> LinearRing? in
         if let sequence = GEOJSONSequenceFromArrayRepresentation(ringCoords),
             let GEOSGeom = GEOSGeom_createLinearRing_r(GEOS_HANDLE, sequence) {
             return LinearRing(storage: GeometryStorage(GEOSGeom: GEOSGeom, parent: nil))
@@ -348,8 +343,7 @@ private func GEOJSONCreatePolygonFromRepresentation(_ representation: NSArray) -
             return LinearRing(storage: GeometryStorage(GEOSGeom: GEOSGeom, parent: nil))
         }
         return nil
-    })
+    }
     let shell = rings.remove(at: 0)
-    let polygon = Polygon(shell: shell, holes: rings)
-    return polygon
+    return Polygon(shell: shell, holes: rings)
 }

--- a/GEOSwift/Geometries.swift
+++ b/GEOSwift/Geometries.swift
@@ -9,10 +9,11 @@
 import Foundation
 
 /**
-A `Waypoint` is a 0-dimensional geometry and represents a single location in coordinate space. A `Waypoint` has a x- coordinate value and a y-coordinate value.
+A `Waypoint` is a 0-dimensional geometry and represents a single location in coordinate space.
+A `Waypoint` has a x- coordinate value and a y-coordinate value.
 The boundary of a `Waypoint` is the empty set.
 */
-open class Waypoint : Geometry {
+open class Waypoint: Geometry {
     open let coordinate: Coordinate
 
     open override class func geometryTypeId() -> Int32 {
@@ -20,17 +21,11 @@ open class Waypoint : Geometry {
     }
 
     public required init(storage: GeometryStorage) {
-        let isValid = GEOSGeomTypeId_r(GEOS_HANDLE, storage.GEOSGeom) == type(of: self).geometryTypeId() // GEOS_POINT
-
-        if (!isValid) {
-            coordinate = Coordinate(x: 0, y: 0)
+        if GEOSGeomTypeId_r(GEOS_HANDLE, storage.GEOSGeom) == type(of: self).geometryTypeId(),
+            let coordinate = CoordinatesCollection(storage: storage).first {
+            self.coordinate = coordinate
         } else {
-            let points = CoordinatesCollection(storage: storage)
-            if points.count > 0 {
-                self.coordinate = points[0]
-            } else {
-                coordinate = Coordinate(x: 0, y: 0)
-            }
+            self.coordinate = Coordinate(x: 0, y: 0)
         }
         super.init(storage: storage)
     }
@@ -47,18 +42,21 @@ open class Waypoint : Geometry {
 }
 
 /**
-A `Polygon` is a planar surface, defined by 1 exterior boundary and 0 or more interior boundaries. Each interior boundary defines a hole in the `Polygon`.
+A `Polygon` is a planar surface, defined by 1 exterior boundary and 0 or more interior boundaries.
+Each interior boundary defines a hole in the `Polygon`.
 
 The assertions for polygons (the rules that define valid polygons) are:
 
 1. Polygons are topologically closed.
 2. The boundary of a Polygon consists of a set of LinearRings that make up its exterior and interior boundaries.
-3. No two rings in the boundary cross, the rings in the boundary of a Polygon may intersect at a Point but only as a tangent.
+3. No two rings in the boundary cross, the rings in the boundary of a Polygon may intersect at a Point but only as a
+   tangent.
 4. A Polygon may not have cut lines, spikes or punctures.
 5. The Interior of every Polygon is a connected point set.
-6. The Exterior of a Polygon with 1 or more holes is not connected. Each hole defines a connected component of the Exterior.
+6. The Exterior of a Polygon with 1 or more holes is not connected. Each hole defines a connected component of the
+   Exterior.
 */
-open class Polygon : Geometry {
+open class Polygon: Geometry {
 
     open override class func geometryTypeId() -> Int32 {
         return 3 // GEOS_POLYGON
@@ -93,20 +91,13 @@ open class Polygon : Geometry {
         let shellGEOSGeom = GEOSGeom_clone_r(GEOS_HANDLE, shell.storage.GEOSGeom)
 
         // clone holes
-        var geometriesPointer: UnsafeMutablePointer<OpaquePointer?>? = nil
-        if let holes = holes, holes.count > 0 {
-            geometriesPointer = UnsafeMutablePointer<OpaquePointer?>.allocate(capacity: holes.count)
-            for (i, geom) in holes.enumerated() {
-                let GEOSGeom = GEOSGeom_clone_r(GEOS_HANDLE, geom.storage.GEOSGeom)
-                geometriesPointer?[i] = GEOSGeom
-            }
+        let count = holes?.count ?? 0
+        var GEOSGeoms = UnsafeMutablePointer<OpaquePointer?>.allocate(capacity: count)
+        defer { GEOSGeoms.deallocate() }
+        holes?.enumerated().forEach { (idx, hole) in
+            GEOSGeoms[idx] = GEOSGeom_clone_r(GEOS_HANDLE, hole.storage.GEOSGeom)
         }
-        defer {
-            if let holes = holes, holes.count > 0 {
-                geometriesPointer?.deallocate()
-            }
-        }
-        guard let geometry = GEOSGeom_createPolygon_r(GEOS_HANDLE, shellGEOSGeom, geometriesPointer, UInt32(holes?.count ?? 0)) else {
+        guard let geometry = GEOSGeom_createPolygon_r(GEOS_HANDLE, shellGEOSGeom, GEOSGeoms, UInt32(count)) else {
             return nil
         }
         self.init(storage: GeometryStorage(GEOSGeom: geometry, parent: nil))
@@ -117,7 +108,7 @@ open class Polygon : Geometry {
  An `Envelope` is a bounding box.
  
 **/
-open class Envelope : Polygon {
+open class Envelope: Polygon {
     public convenience init?(p1: Coordinate, p2: Coordinate) {
         let (maxX, maxY, minX, minY) = (max(p1.x, p2.x), max(p1.y, p2.y), min(p1.x, p2.x), min(p1.y, p2.y))
         guard let shell = LinearRing(points: [
@@ -126,23 +117,23 @@ open class Envelope : Polygon {
             Coordinate(x: maxX, y: maxY),
             Coordinate(x: minX, y: maxY),
             Coordinate(x: minX, y: minY)]) else { return nil }
-        
+
         let shellGEOSGeom = GEOSGeom_clone_r(GEOS_HANDLE, shell.storage.GEOSGeom)
-        
+
         guard let geometry = GEOSGeom_createPolygon_r(GEOS_HANDLE, shellGEOSGeom, nil, UInt32(0)) else {
             return nil
         }
         self.init(storage: GeometryStorage(GEOSGeom: geometry, parent: nil))
     }
-    
+
     public class func byExpanding(_ base: Envelope, toInclude geom: Geometry) -> Envelope? {
         return base.union(geom)?.envelope()
     }
-    
+
     public class func byExpanding(_ base: Envelope, toIncludeCoordinate coord: Coordinate) -> Envelope? {
         return Waypoint(latitude: coord.y, longitude: coord.x).flatMap { base.union($0)?.envelope() }
     }
-    
+
     public var maxX: Double {
         return exteriorRing.points[2].x
     }
@@ -174,21 +165,22 @@ open class Envelope : Polygon {
 }
 
 /**
-    A `LineString` is a Curve with linear interpolation between points. Each consecutive pair of points defines a line segment.
+    A `LineString` is a Curve with linear interpolation between points.
+    Each consecutive pair of points defines a line segment.
 */
-open class LineString : Geometry {
-    
+open class LineString: Geometry {
+
     open override class func geometryTypeId() -> Int32 {
         return 1 // GEOS_LINESTRING
     }
-    
+
     fileprivate(set) open lazy var points: CoordinatesCollection = {
-        return CoordinatesCollection(storage: storage)
+        CoordinatesCollection(storage: storage)
         }()
-    
+
     public convenience init?(points: [Coordinate]) {
         let seq = GEOSCoordSeq_create_r(GEOS_HANDLE, UInt32(points.count), 2)
-        for (i,coord) in points.enumerated() {
+        for (i, coord) in points.enumerated() {
             GEOSCoordSeq_setX_r(GEOS_HANDLE, seq, UInt32(i), coord.x)
             GEOSCoordSeq_setY_r(GEOS_HANDLE, seq, UInt32(i), coord.y)
         }
@@ -206,7 +198,7 @@ open class LineString : Geometry {
 /**
     A LinearRing is a LineString that is both closed and simple.
 */
-open class LinearRing : LineString {
+open class LinearRing: LineString {
 
     override public class func GEOSGeom(from seq: OpaquePointer?) -> OpaquePointer? {
         return GEOSGeom_createLinearRing_r(GEOS_HANDLE, seq)
@@ -218,13 +210,13 @@ open class LinearRing : LineString {
 A GeometryCollection is a geometry that is a collection of 1 or more geometries.
 */
 open class GeometryCollection<T: Geometry> : Geometry {
-    
+
     open override class func geometryTypeId() -> Int32 {
         return 7 // GEOS_GEOMETRYCOLLECTION
     }
-    
+
     fileprivate(set) open lazy var geometries: GeometriesCollection<T> = {
-        return GeometriesCollection<T>(storage: storage)
+        GeometriesCollection<T>(storage: storage)
     }()
 
     /**
@@ -237,8 +229,11 @@ open class GeometryCollection<T: Geometry> : Geometry {
             let GEOSGeom = GEOSGeom_clone_r(GEOS_HANDLE, geom.storage.GEOSGeom)
             geometriesPointer[i] = GEOSGeom
         }
-        
-        guard let geometry = GEOSGeom_createCollection_r(GEOS_HANDLE, type(of: self).geometryTypeId(), geometriesPointer, UInt32(geometries.count)) else {
+
+        guard let geometry = GEOSGeom_createCollection_r(GEOS_HANDLE,
+                                                         type(of: self).geometryTypeId(),
+                                                         geometriesPointer,
+                                                         UInt32(geometries.count)) else {
             return nil
         }
         self.init(storage: GeometryStorage(GEOSGeom: geometry, parent: nil))
@@ -249,7 +244,7 @@ open class GeometryCollection<T: Geometry> : Geometry {
 A `MultiLineString` is a `GeometryCollection` of `LineStrings`.
 */
 open class MultiLineString<T: LineString> : GeometryCollection<T> {
-    
+
     open override class func geometryTypeId() -> Int32 {
         return 5 // GEOS_MULTILINESTRING
     }
@@ -261,8 +256,11 @@ open class MultiLineString<T: LineString> : GeometryCollection<T> {
             let GEOSGeom = GEOSGeom_clone_r(GEOS_HANDLE, geom.storage.GEOSGeom)
             geometriesPointer[i] = GEOSGeom
         }
-        
-        guard let geometry = GEOSGeom_createCollection_r(GEOS_HANDLE, type(of: self).geometryTypeId(), geometriesPointer, UInt32(linestrings.count)) else {
+
+        guard let geometry = GEOSGeom_createCollection_r(GEOS_HANDLE,
+                                                         type(of: self).geometryTypeId(),
+                                                         geometriesPointer,
+                                                         UInt32(linestrings.count)) else {
             return nil
         }
         self.init(storage: GeometryStorage(GEOSGeom: geometry, parent: nil))
@@ -283,13 +281,16 @@ open class MultiPoint<T: Waypoint> : GeometryCollection<T> {
             let GEOSGeom = GEOSGeom_clone_r(GEOS_HANDLE, geom.storage.GEOSGeom)
             coordsPointer[i] = GEOSGeom
         }
-        
-        guard let geometry = GEOSGeom_createCollection_r(GEOS_HANDLE, type(of: self).geometryTypeId(), coordsPointer, UInt32(points.count)) else {
+
+        guard let geometry = GEOSGeom_createCollection_r(GEOS_HANDLE,
+                                                         type(of: self).geometryTypeId(),
+                                                         coordsPointer,
+                                                         UInt32(points.count)) else {
             return nil
         }
         self.init(storage: GeometryStorage(GEOSGeom: geometry, parent: nil))
     }
-    
+
 }
 
 /**
@@ -306,8 +307,11 @@ open class MultiPolygon<T: Polygon> : GeometryCollection<T> {
             let GEOSGeom = GEOSGeom_clone_r(GEOS_HANDLE, geom.storage.GEOSGeom)
             coordsPointer[i] = GEOSGeom
         }
-        
-        guard let geometry = GEOSGeom_createCollection_r(GEOS_HANDLE, type(of: self).geometryTypeId(), coordsPointer, UInt32(polygons.count)) else {
+
+        guard let geometry = GEOSGeom_createCollection_r(GEOS_HANDLE,
+                                                         type(of: self).geometryTypeId(),
+                                                         coordsPointer,
+                                                         UInt32(polygons.count)) else {
             return nil
         }
         self.init(storage: GeometryStorage(GEOSGeom: geometry, parent: nil))

--- a/GEOSwift/Geometries.swift
+++ b/GEOSwift/Geometries.swift
@@ -174,9 +174,9 @@ open class LineString: Geometry {
         return 1 // GEOS_LINESTRING
     }
 
-    fileprivate(set) open lazy var points: CoordinatesCollection = {
+    open lazy var points: CoordinatesCollection = {
         CoordinatesCollection(storage: storage)
-        }()
+    }()
 
     public convenience init?(points: [Coordinate]) {
         let seq = GEOSCoordSeq_create_r(GEOS_HANDLE, UInt32(points.count), 2)

--- a/GEOSwift/LinearRef.swift
+++ b/GEOSwift/LinearRef.swift
@@ -11,27 +11,27 @@ import Foundation
  Linear referencing functions
  */
 public extension LineString {
-    
+
     /// - returns: The distance of a point projected on the calling line
     public func distanceFromOriginToProjectionOfPoint(point: Waypoint) -> Double {
-        return GEOSProject_r(GEOS_HANDLE, geometry, point.geometry);
+        return GEOSProject_r(GEOS_HANDLE, geometry, point.geometry)
     }
-    
+
     public func normalizedDistanceFromOriginToProjectionOfPoint(point: Waypoint) -> Double {
-        return GEOSProjectNormalized_r(GEOS_HANDLE, geometry, point.geometry);
+        return GEOSProjectNormalized_r(GEOS_HANDLE, geometry, point.geometry)
     }
-    
+
     /// Return closest point to given distance within geometry
     public func interpolatePoint(distance: Double) -> Waypoint {
         let interpolatedPoint = GEOSInterpolate_r(GEOS_HANDLE, geometry, distance)
         return Waypoint(GEOSGeom: interpolatedPoint!)
     }
-    
+
     public func interpolatePoint(fraction: Double) -> Waypoint {
         let interpolatedPoint = GEOSInterpolateNormalized_r(GEOS_HANDLE, geometry, fraction)
         return Waypoint(GEOSGeom: interpolatedPoint!)
     }
-    
+
     public func middlePoint() -> Waypoint {
         return self.interpolatePoint(fraction: 0.5)
     }

--- a/GEOSwift/MiscFunctions.swift
+++ b/GEOSwift/MiscFunctions.swift
@@ -16,17 +16,9 @@ public extension Geometry {
     /// - returns: The distance between the two geometries, expressed in the SRID of the first
     func distance(geometry: Geometry) -> Double {
         var dist: Double = 0
-        
+
         let result = GEOSDistance_r(GEOS_HANDLE, self.geometry, geometry.geometry, &dist)
         assert (result == 1)
         return dist
     }
-
-    // TODO: implement other misc functions
-//    public func GEOSArea_r(handle: GEOSContextHandle_t, _ g: COpaquePointer, _ area: UnsafeMutablePointer<Double>) -> Int32
-//    public func GEOSLength_r(handle: GEOSContextHandle_t, _ g: COpaquePointer, _ length: UnsafeMutablePointer<Double>) -> Int32
-//    public func GEOSHausdorffDistance_r(handle: GEOSContextHandle_t, _ g1: COpaquePointer, _ g2: COpaquePointer, _ dist: UnsafeMutablePointer<Double>) -> Int32
-//    public func GEOSHausdorffDistanceDensify_r(handle: GEOSContextHandle_t, _ g1: COpaquePointer, _ g2: COpaquePointer, _ densifyFrac: Double, _ dist: UnsafeMutablePointer<Double>) -> Int32
-//    public func GEOSGeomGetLength_r(handle: GEOSContextHandle_t, _ g: COpaquePointer, _ length: UnsafeMutablePointer<Double>) -> Int32
-
 }

--- a/GEOSwift/QuickLook.swift
+++ b/GEOSwift/QuickLook.swift
@@ -14,80 +14,73 @@ protocol GEOSwiftQuickLook {
 
 public extension Geometry {
 
-    @objc
-    public func debugQuickLookObject() -> AnyObject? {
-        
+    // swiftlint:disable:next function_body_length
+    @objc public func debugQuickLookObject() -> AnyObject? {
+
         let region: MKCoordinateRegion
         if let point = self as? Waypoint {
-            let center = CLLocationCoordinate2DMake(point.coordinate.y, point.coordinate.x)
-            let span = MKCoordinateSpanMake(0.1, 0.1)
-            region = MKCoordinateRegionMake(center,span)
+            let center = CLLocationCoordinate2D(latitude: point.coordinate.y, longitude: point.coordinate.x)
+            let span = MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
+            region = MKCoordinateRegion(center: center, span: span)
+        } else if let envelope = self.envelope(), let centroid = envelope.centroid() {
+            let center = CLLocationCoordinate2D(latitude: centroid.coordinate.y, longitude: centroid.coordinate.x)
+            let exteriorRing = envelope.exteriorRing
+            let upperLeft = exteriorRing.points[2]
+            let lowerRight = exteriorRing.points[0]
+            let span = MKCoordinateSpan(latitudeDelta: upperLeft.y - lowerRight.y,
+                                        longitudeDelta: upperLeft.x - lowerRight.x)
+            region = MKCoordinateRegion(center: center, span: span)
         } else {
-            if let envelope = self.envelope() {
-                guard let centroid = envelope.centroid() else { return nil }
-                let center = CLLocationCoordinate2DMake(centroid.coordinate.y, centroid.coordinate.x)
-                let exteriorRing = envelope.exteriorRing
-                let upperLeft = exteriorRing.points[2]
-                let lowerRight = exteriorRing.points[0]
-                let span = MKCoordinateSpanMake(upperLeft.y - lowerRight.y, upperLeft.x - lowerRight.x)
-                region = MKCoordinateRegionMake(center, span)
-            } else {
-                return nil
-            }
+            return nil
         }
+
         let mapView = MKMapView()
-        
         mapView.mapType = .standard
         mapView.frame = CGRect(x: 0, y: 0, width: 400, height: 400)
         mapView.region = region
-        
+
         let options = MKMapSnapshotOptions()
         options.region = mapView.region
         options.scale = UIScreen.main.scale
         options.size = mapView.frame.size
-        
+
         // take a snapshot of the map with MKMapSnapshot:
         // it is designed to work in background, so we have to block the main thread using a semaphore
         var mapViewImage: UIImage?
-        let qualityOfServiceClass = DispatchQoS.QoSClass.background
-        let backgroundQueue = DispatchQueue.global(qos: qualityOfServiceClass)
+        let backgroundQueue = DispatchQueue.global(qos: .background)
         let snapshotter = MKMapSnapshotter(options: options)
-        let semaphore = DispatchSemaphore(value: 0);
+        let semaphore = DispatchSemaphore(value: 0)
         let mapRect = mapView.visibleMapRect
-//        let boundingBox = MKMapRect(region)
-            
-        snapshotter.start(with: backgroundQueue) { snapshot, error in
+
+        snapshotter.start(with: backgroundQueue) { snapshot, _ in
             guard let snapshot = snapshot else {
                 semaphore.signal()
                 return
             }
-            
+
             // let the single geometry draw itself on the map
             let image = snapshot.image
-//            let finalImageRect = CGRectMake(0, 0, image.size.width, image.size.height)
-            
-            UIGraphicsBeginImageContextWithOptions(image.size, true, image.scale);
+
+            UIGraphicsBeginImageContextWithOptions(image.size, true, image.scale)
             image.draw(at: CGPoint(x: 0, y: 0))
-            
+
             guard let context = UIGraphicsGetCurrentContext() else {
                 fatalError("Could not get current context")
             }
             let scaleX = image.size.width / CGFloat(mapRect.size.width)
             let scaleY = image.size.height / CGFloat(mapRect.size.height)
-            //            CGContextTranslateCTM(context, (image.size.width - CGFloat(boundingBox.size.width) * scaleX) / 2, (image.size.height - CGFloat(boundingBox.size.height) * scaleY) / 2)
             context.scaleBy(x: scaleX, y: scaleY)
             if let geom = self as? GEOSwiftQuickLook {
                 geom.drawInSnapshot(snapshot, mapRect: mapRect)
             }
             let finalImage = UIGraphicsGetImageFromCurrentImageContext()
             UIGraphicsEndImageContext()
-            
+
             mapViewImage = finalImage
-            
+
             semaphore.signal()
         }
-        let delayTime = DispatchTime.now() + Double(Int64(3 * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)
-        let _ = semaphore.wait(timeout: delayTime)
+        _ = semaphore.wait(timeout: .now() + 3)
 
         // Sometimes this fails.. Fallback to WKT representation
         if let mapViewImage = mapViewImage {
@@ -98,31 +91,19 @@ public extension Geometry {
     }
 }
 
-private func MKMapRect(_ region: MKCoordinateRegion) ->MKMapRect
-{
-    let a = MKMapPointForCoordinate(CLLocationCoordinate2DMake(
-        region.center.latitude + region.span.latitudeDelta / 2,
-        region.center.longitude - region.span.longitudeDelta / 2));
-    let b = MKMapPointForCoordinate(CLLocationCoordinate2DMake(
-        region.center.latitude - region.span.latitudeDelta / 2,
-        region.center.longitude + region.span.longitudeDelta / 2));
-    return MKMapRectMake(min(a.x,b.x), min(a.y,b.y), abs(a.x-b.x), abs(a.y-b.y));
-}
-
-extension Waypoint : GEOSwiftQuickLook {
+extension Waypoint: GEOSwiftQuickLook {
     func drawInSnapshot(_ snapshot: MKMapSnapshot, mapRect: MKMapRect) {
         let image = snapshot.image
-        
-//        let finalImageRect = CGRectMake(0, 0, image.size.width, image.size.height)
+
         let pin = MKPinAnnotationView(annotation: nil, reuseIdentifier: "")
         if let pinImage = pin.image {
-        
-            UIGraphicsBeginImageContextWithOptions(image.size, true, image.scale);
-            
+
+            UIGraphicsBeginImageContextWithOptions(image.size, true, image.scale)
+
             image.draw(at: CGPoint(x: 0, y: 0))
-            
+
             // draw center/home marker
-            let coord = CLLocationCoordinate2DMake(self.coordinate.y, self.coordinate.x)
+            let coord = CLLocationCoordinate2D(latitude: self.coordinate.y, longitude: self.coordinate.x)
             let homePoint = snapshot.point(for: coord)
             var rect = CGRect(x: 0, y: 0, width: pinImage.size.width, height: pinImage.size.height)
             rect = rect.offsetBy(dx: homePoint.x-rect.size.width/2.0, dy: homePoint.y-rect.size.height)
@@ -131,57 +112,59 @@ extension Waypoint : GEOSwiftQuickLook {
     }
 }
 
-extension LineString : GEOSwiftQuickLook {
+extension LineString: GEOSwiftQuickLook {
     func drawInSnapshot(_ snapshot: MKMapSnapshot, mapRect: MKMapRect) {
-        
+
         if let overlay = self.mapShape() as? MKOverlay {
             let zoomScale = snapshot.image.size.width / CGFloat(mapRect.size.width)
-            
+
             let renderer = MKPolylineRenderer(overlay: overlay)
             renderer.lineWidth = 2
             renderer.strokeColor = UIColor.blue.withAlphaComponent(0.7)
-            
+
             if let context = UIGraphicsGetCurrentContext() {
-                context.saveGState();
-                
+                context.saveGState()
+
                 // the renderer will draw the geometry at 0;0, so offset CoreGraphics by the right measure
                 let upperCorner = renderer.mapPoint(for: CGPoint.zero)
-                context.translateBy(x: CGFloat(upperCorner.x - mapRect.origin.x), y: CGFloat(upperCorner.y - mapRect.origin.y));
-                
+                context.translateBy(x: CGFloat(upperCorner.x - mapRect.origin.x),
+                                    y: CGFloat(upperCorner.y - mapRect.origin.y))
+
                 renderer.draw(mapRect, zoomScale: zoomScale, in: context)
-                context.restoreGState();
+                context.restoreGState()
             }
         }
     }
 }
 
-extension Polygon : GEOSwiftQuickLook {
+extension Polygon: GEOSwiftQuickLook {
     func drawInSnapshot(_ snapshot: MKMapSnapshot, mapRect: MKMapRect) {
-        
+
         if let overlay = self.mapShape() as? MKOverlay {
             let zoomScale = snapshot.image.size.width / CGFloat(mapRect.size.width)
-            
+
             let polygonRenderer = MKPolygonRenderer(overlay: overlay)
             polygonRenderer.lineWidth = 2
             polygonRenderer.strokeColor = UIColor.blue.withAlphaComponent(0.7)
             polygonRenderer.fillColor = UIColor.cyan.withAlphaComponent(0.2)
-            
+
             if let context = UIGraphicsGetCurrentContext() {
-                context.saveGState();
-                
+                context.saveGState()
+
                 // the renderer will draw the geometry at 0;0, so offset CoreGraphics by the right measure
                 let upperCorner = polygonRenderer.mapPoint(for: CGPoint.zero)
-                context.translateBy(x: CGFloat(upperCorner.x - mapRect.origin.x), y: CGFloat(upperCorner.y - mapRect.origin.y));
-                
+                context.translateBy(x: CGFloat(upperCorner.x - mapRect.origin.x),
+                                    y: CGFloat(upperCorner.y - mapRect.origin.y))
+
                 polygonRenderer.draw(mapRect, zoomScale: zoomScale, in: context)
 
-                context.restoreGState();
+                context.restoreGState()
             }
         }
     }
 }
 
-extension GeometryCollection : GEOSwiftQuickLook {
+extension GeometryCollection: GEOSwiftQuickLook {
     func drawInSnapshot(_ snapshot: MKMapSnapshot, mapRect: MKMapRect) {
         for geometry in self.geometries {
             if let geom = geometry as? GEOSwiftQuickLook {

--- a/GEOSwift/SpatialAnalysis.swift
+++ b/GEOSwift/SpatialAnalysis.swift
@@ -9,13 +9,16 @@ import Foundation
 
 /// Topological operations
 public extension Geometry {
-    
-    /// - returns: A Polygon that represents all points whose distance from this geometry is less than or equal to the given width.
+
+    /**
+     - returns: A Polygon that represents all points whose distance from this geometry is less than or equal to the
+                given width.
+     */
     func buffer(width: Double) -> Geometry? {
         guard let bufferGEOM = GEOSBuffer_r(GEOS_HANDLE, storage.GEOSGeom, width, 0) else { return nil }
         return Geometry.create(storage: GeometryStorage(GEOSGeom: bufferGEOM, parent: nil))
     }
-    
+
     /// - returns: The smallest Polygon that contains all the points in the geometry.
     func convexHull() -> Polygon? {
         guard let convexHullGEOM = GEOSConvexHull_r(GEOS_HANDLE, storage.GEOSGeom) else { return nil }
@@ -23,80 +26,90 @@ public extension Geometry {
     }
 
     /// - returns: a Geometry representing the points shared by this geometry and other.
-    func intersection(_ geometry: Geometry) -> Geometry?  {
-        guard let intersectionGEOM = GEOSIntersection_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom) else { return nil }
+    func intersection(_ geometry: Geometry) -> Geometry? {
+        guard let intersectionGEOM = GEOSIntersection_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom) else {
+            return nil
+        }
         return Geometry.create(storage: GeometryStorage(GEOSGeom: intersectionGEOM, parent: nil))
     }
-    
+
     /// - returns: A Geometry representing all the points in this geometry and the other.
-    func union(_ geometry: Geometry) -> Geometry?  {
+    func union(_ geometry: Geometry) -> Geometry? {
         guard let unionGEOM = GEOSUnion_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom) else { return nil }
         return Geometry.create(storage: GeometryStorage(GEOSGeom: unionGEOM, parent: nil))
     }
-    
+
     /// - returns: A Geometry representing all the points in this geometry and the other.
-    func unaryUnion() -> Geometry?  {
+    func unaryUnion() -> Geometry? {
         guard let unionGEOM = GEOSUnaryUnion_r(GEOS_HANDLE, storage.GEOSGeom) else { return nil }
         return Geometry.create(storage: GeometryStorage(GEOSGeom: unionGEOM, parent: nil))
     }
-    
+
     /// - returns: A Geometry representing the points making up this geometry that do not make up other.
-    func difference(_ geometry: Geometry) -> Geometry?  {
-        guard let differenceGEOM = GEOSDifference_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom) else { return nil }
+    func difference(_ geometry: Geometry) -> Geometry? {
+        guard let differenceGEOM = GEOSDifference_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom) else {
+            return nil
+        }
         return Geometry.create(storage: GeometryStorage(GEOSGeom: differenceGEOM, parent: nil))
     }
-    
+
     /// - returns: The boundary as a newly allocated Geometry object.
-    func boundary() -> Geometry?  {
+    func boundary() -> Geometry? {
         guard let boundaryGEOM = GEOSBoundary_r(GEOS_HANDLE, storage.GEOSGeom) else { return nil }
         return Geometry.create(storage: GeometryStorage(GEOSGeom: boundaryGEOM, parent: nil))
     }
-    
-    /// - returns: A Waypoint representing the geometric center of the geometry. The point is not guaranteed to be on the interior of the geometry.
+
+    /**
+     - returns: A Waypoint representing the geometric center of the geometry. The point is not guaranteed to be on the
+                interior of the geometry.
+     */
     func centroid() -> Waypoint? {
         guard let centroidGEOM = GEOSGetCentroid_r(GEOS_HANDLE, storage.GEOSGeom) else { return nil }
         return Geometry.create(storage: GeometryStorage(GEOSGeom: centroidGEOM, parent: nil)) as? Waypoint
     }
-    
+
     /// - returns: A Polygon that represents the bounding envelope of this geometry.
     func envelope() -> Envelope? {
         guard let envelopeGEOM = GEOSEnvelope_r(GEOS_HANDLE, storage.GEOSGeom) else { return nil }
         return Envelope(storage: GeometryStorage(GEOSGeom: envelopeGEOM, parent: nil))
     }
-    
+
     /// - returns: A POINT guaranteed to lie on the surface.
     func pointOnSurface() -> Waypoint? {
         guard let pointOnSurfaceGEOM = GEOSPointOnSurface_r(GEOS_HANDLE, storage.GEOSGeom) else { return nil }
         return Geometry.create(storage: GeometryStorage(GEOSGeom: pointOnSurfaceGEOM, parent: nil)) as? Waypoint
     }
-    
+
     /// - returns: The nearest point of this geometry with respect to `geometry`.
     func nearestPoint(_ geometry: Geometry) -> Coordinate {
         return nearestPoints(geometry)[0]
     }
-    
+
     /// - returns: The nearest points in the geometries, ownership to caller.
     func nearestPoints(_ geometry: Geometry) -> [Coordinate] {
         let nearestPointsCoordinateList = GEOSNearestPoints_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom)
-        var x0 : Double = 0
-        var y0 : Double = 0
+        var x0: Double = 0
+        var y0: Double = 0
         GEOSCoordSeq_getX_r(GEOS_HANDLE, nearestPointsCoordinateList, 0, &x0)
         GEOSCoordSeq_getY_r(GEOS_HANDLE, nearestPointsCoordinateList, 0, &y0)
-        
-        var x1 : Double = 0
-        var y1 : Double = 0
+
+        var x1: Double = 0
+        var y1: Double = 0
         GEOSCoordSeq_getX_r(GEOS_HANDLE, nearestPointsCoordinateList, 1, &x1)
         GEOSCoordSeq_getY_r(GEOS_HANDLE, nearestPointsCoordinateList, 1, &y1)
-        
+
         return [Coordinate(x: x0, y: y0), Coordinate(x: x1, y: y1)]
     }
-    
-    /// - returns: The DE-9IM intersection matrix (a string) representing the topological relationship between this geometry and the other.
+
+    /**
+     - returns: The DE-9IM intersection matrix (a string) representing the topological relationship between this
+                geometry and the other.
+     */
     func relationship(_ geometry: Geometry) -> String {
         guard let CString = GEOSRelate_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom) else { return "" }
         return String(cString: CString)
     }
-    
+
     /// - returns: The area of this geometry, or nil on error
     func area() -> Double? {
         var area: Double = 0

--- a/GEOSwift/SpatialRelations.swift
+++ b/GEOSwift/SpatialRelations.swift
@@ -10,62 +10,66 @@ import Foundation
 /** 
 Spatial predicates methods
 
-All of the following spatial predicate methods take another Geometry instance (other) as a parameter, and return a boolean.
+All of the following spatial predicate methods take another Geometry instance (other) as a parameter and return a bool.
 */
 public extension Geometry {
- 
+
     /// - returns: TRUE if the geometry is spatially equal to `geometry`
     public func equals(_ geometry: Geometry) -> Bool {
-        return GEOSEquals_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom) > 0;
+        return GEOSEquals_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom) > 0
     }
-    
+
     /// - returns: TRUE if the geometry is spatially disjoint to `geometry`
     public func disjoint(_ geometry: Geometry) -> Bool {
-        return GEOSDisjoint_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom) > 0;
+        return GEOSDisjoint_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom) > 0
     }
-    
+
     /// - returns: TRUE if the geometry spatially touches `geometry`
     public func touches(_ geometry: Geometry) -> Bool {
-        return GEOSTouches_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom) > 0;
+        return GEOSTouches_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom) > 0
     }
-    
+
     /// - returns: TRUE if the geometry spatially intersects `geometry`
     public func intersects(_ geometry: Geometry) -> Bool {
-        return GEOSIntersects_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom) > 0;
+        return GEOSIntersects_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom) > 0
     }
-    
+
     /// - returns: TRUE if the geometry spatially crosses `geometry`
     public func crosses(_ geometry: Geometry) -> Bool {
-        return GEOSCrosses_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom) > 0;
+        return GEOSCrosses_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom) > 0
     }
-    
+
     /// - returns: TRUE if the geometry is spatially within `geometry`
     public func within(_ geometry: Geometry) -> Bool {
-        return GEOSWithin_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom) > 0;
+        return GEOSWithin_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom) > 0
     }
-    
+
     /// - returns: TRUE if the geometry spatially contains `geometry`
     public func contains(_ geometry: Geometry) -> Bool {
-        return GEOSContains_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom) > 0;
+        return GEOSContains_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom) > 0
     }
-    
+
     /// - returns: TRUE if the geometry spatially overlaps `geometry`
     public func overlaps(_ geometry: Geometry) -> Bool {
-        return GEOSOverlaps_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom) > 0;
+        return GEOSOverlaps_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom) > 0
     }
-    
+
     /// - returns: TRUE if the geometry spatially covers `geometry`
-    public func covers(_ geometry : Geometry) -> Bool {
+    public func covers(_ geometry: Geometry) -> Bool {
         return GEOSCovers_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom) > 0
     }
 
     /**
     - parameter pattern: A String following the Dimensionally Extended Nine-Intersection Model (DE-9IM).
     
-    - returns: TRUE if the geometry spatially relates `geometry`, by testing for intersections between the Interior, Boundary and Exterior of the two geometries as specified by the values in the pattern.
+    - returns: TRUE if the geometry spatially relates `geometry`, by testing for intersections between the
+               Interior, Boundary and Exterior of the two geometries as specified by the values in the pattern.
     */
     public func relate(_ geometry: Geometry, pattern: String) -> Bool {
-        return GEOSRelatePattern_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom, (pattern as NSString).utf8String) > 0;
+        return GEOSRelatePattern_r(GEOS_HANDLE,
+                                   storage.GEOSGeom,
+                                   geometry.storage.GEOSGeom,
+                                   (pattern as NSString).utf8String) > 0
     }
 
 }

--- a/GEOSwiftTests/GEOSTests.swift
+++ b/GEOSwiftTests/GEOSTests.swift
@@ -9,6 +9,7 @@ import Foundation
 import XCTest
 import GEOSwift
 
+// swiftlint:disable:next type_body_length
 class GEOSwiftTests: XCTestCase {
 
     var waypoint: Waypoint!
@@ -38,7 +39,7 @@ class GEOSwiftTests: XCTestCase {
         geometryCollection = GeometryCollection(geometries: [waypoint, lineString])
         multiPoint = MultiPoint(points: [waypoint])
     }
-    
+
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         multiPoint = nil
@@ -85,7 +86,6 @@ class GEOSwiftTests: XCTestCase {
         XCTAssertEqual(testPolygon, polygon)
     }
 
-
     func testInitGeometryCollectionFromWKT() {
         let WKT = "GEOMETRYCOLLECTION(POINT(45 9),LINESTRING(3 4,10 50,20 25))"
         guard let testGeometryCollection = GeometryCollection(WKT: WKT) else {
@@ -120,7 +120,7 @@ class GEOSwiftTests: XCTestCase {
         }
         XCTAssertEqual(testLineString, lineString)
     }
-    
+
     func testCreateLinearRingFromWKT() {
         guard let testLinearRing = Geometry.create("LINEARRING(35 10,45 45,15 40,10 20,35 10)") as? LinearRing else {
             XCTFail("WKT parse failed (expected to receive a LINEARRING)")
@@ -137,7 +137,7 @@ class GEOSwiftTests: XCTestCase {
         }
         XCTAssertEqual(testPolygon, polygon)
     }
-    
+
     func testCreateGeometryCollectionFromWKT() {
         let WKT = "GEOMETRYCOLLECTION(POINT(45 9),LINESTRING(3 4,10 50,20 25))"
         guard let testGeometryCollection = Geometry.create(WKT) as? GeometryCollection else {
@@ -171,36 +171,39 @@ class GEOSwiftTests: XCTestCase {
     // Test case for Issue #37
     // https://github.com/GEOSwift/GEOSwift/issues/37
     func testCreatePolygonFromLinearRing() {
-        let lr = LinearRing(points: [Coordinate(x:-10, y:10), Coordinate(x:10, y:10), Coordinate(x:10, y:-10), Coordinate(x:-10, y:-10), Coordinate(x:-10, y:10)])
+        let lr = LinearRing(points: [Coordinate(x: -10, y: 10),
+                                     Coordinate(x: 10, y: 10),
+                                     Coordinate(x: 10, y: -10),
+                                     Coordinate(x: -10, y: -10),
+                                     Coordinate(x: -10, y: 10)])
         XCTAssertNotNil(lr, "Failed to create LinearRing")
-        
-        if let lr = lr
-        {
+
+        if let lr = lr {
             let polygon1 = Polygon(shell: lr, holes: nil)
             XCTAssertNotNil(polygon1, "Failed to create polygon from LinearRing")
         }
     }
 
     func testCreateEnvelopeFromCoordinates() {
-        let env = Envelope(p1: Coordinate(x:-10, y:10), p2: Coordinate(x:10, y:-10))
+        let env = Envelope(p1: Coordinate(x: -10, y: 10), p2: Coordinate(x: 10, y: -10))
         XCTAssertNotNil(env, "Failed to create Envelope")
         let geom = env!.envelope()
         XCTAssertEqual(env, geom)
     }
-    
+
     func testCreateEnvelopeByExpanding() {
-        let env = Envelope(p1: Coordinate(x:-10, y:10), p2: Coordinate(x:10, y:-10))
+        let env = Envelope(p1: Coordinate(x: -10, y: 10), p2: Coordinate(x: 10, y: -10))
         XCTAssertNotNil(env, "Failed to create Envelope")
         let newEnv = Envelope.byExpanding(env!, toInclude: Waypoint(latitude: 11, longitude: 11)!)
         XCTAssertNotNil(env, "Failed to expand Envelope")
-        XCTAssertEqual(newEnv!,  Envelope(p1: Coordinate(x:-10, y:11), p2: Coordinate(x:11, y:-10))!)
+        XCTAssertEqual(newEnv!, Envelope(p1: Coordinate(x: -10, y: 11), p2: Coordinate(x: 11, y: -10))!)
     }
 
     func testGeoJSON() {
         let bundle = Bundle(for: GEOSwiftTests.self)
         if let geojsons = bundle.urls(forResourcesWithExtension: "geojson", subdirectory: nil) {
             for geoJSONURL in geojsons {
-                if let _ = try! Features.fromGeoJSON(geoJSONURL)  {
+                if case .some(.some) = try? Features.fromGeoJSON(geoJSONURL) {
                     XCTAssert(true, "GeoJSON correctly parsed")
                 } else {
                     XCTAssert(false, "Can't extract geometry from GeoJSON: \(geoJSONURL.lastPathComponent)")
@@ -208,34 +211,35 @@ class GEOSwiftTests: XCTestCase {
             }
         }
     }
-    
+
     func testNearestPoints() {
+        let polygonWKT = "POLYGON((35 10, 45 45, 15 40, 10 20, 35 10),(20 30, 35 35, 30 20, 20 30))"
         let point = Geometry.create("POINT(45 9)") as! Waypoint
-        let polygon = Geometry.create("POLYGON((35 10, 45 45, 15 40, 10 20, 35 10),(20 30, 35 35, 30 20, 20 30))") as! Polygon
-        
+        let polygon = Geometry.create(polygonWKT) as! Polygon
+
         let arrNearestPoints = point.nearestPoints(polygon)
-        
+
         XCTAssertNotNil(arrNearestPoints, "Failed to get nearestPoints array between the two geometries")
         XCTAssertEqual(arrNearestPoints.count, 2, "Number of expected points is 2")
 
         XCTAssertEqual(arrNearestPoints[0].x, point.nearestPoint(polygon).x)
         XCTAssertEqual(arrNearestPoints[0].y, point.nearestPoint(polygon).y)
-        
     }
 
     func testArea() {
         let point = Geometry.create("POINT(45 9)") as! Waypoint
         XCTAssertEqual(0, point.area())
-        
+
         let lr = LinearRing(points: [Coordinate(x: 0, y: 0),
-                                    Coordinate(x: 1, y: 0),
-                                    Coordinate(x: 1, y: 1),
-                                    Coordinate(x: 0, y: 1),
-                                    Coordinate(x: 0, y: 0)])!
+                                     Coordinate(x: 1, y: 0),
+                                     Coordinate(x: 1, y: 1),
+                                     Coordinate(x: 0, y: 1),
+                                     Coordinate(x: 0, y: 0)])!
         let polygon = Polygon(shell: lr, holes: nil)!
         XCTAssertEqual(1, polygon.area())
     }
-    
+
+    // swiftlint:disable:next function_body_length
     func testIsEqual() {
         let lhs = LineString(points: [Coordinate(x: 0, y: 0),
                                       Coordinate(x: 1, y: 0),

--- a/GEOSwiftTests/GEOSTests.swift
+++ b/GEOSwiftTests/GEOSTests.swift
@@ -322,4 +322,14 @@ class GEOSwiftTests: XCTestCase {
         // would crash when accessing the LineString storage.
         XCTAssertEqual(element, lineString)
     }
+
+    func testCoordinatesCollection() {
+        let collection = lineString.points
+
+        XCTAssertEqual(collection.startIndex, 0)
+        XCTAssertEqual(collection.endIndex, collection.count)
+        XCTAssertEqual(collection.index(after: 0), 1)
+        XCTAssertEqual(collection.index(after: 1), 2)
+        XCTAssertEqual(collection.index(after: 2), 3)
+    }
 }

--- a/GEOSwiftTests/GeoJSONTests.swift
+++ b/GEOSwiftTests/GeoJSONTests.swift
@@ -13,12 +13,10 @@ final class GeoJSONTests: XCTestCase {
             return
         }
         for geoJSONURL in geojsons {
-            guard let geometries = try! Features.fromGeoJSON(geoJSONURL) else {
+            guard case .some(.some) = try? Features.fromGeoJSON(geoJSONURL) else {
                 XCTFail("Can't extract geometry from GeoJSON: \(geoJSONURL.lastPathComponent)")
                 continue
             }
-//                geometries[0].debugQuickLookObject()
-            print("\(geoJSONURL.lastPathComponent): \(geometries)")
         }
     }
 
@@ -29,13 +27,11 @@ final class GeoJSONTests: XCTestCase {
             return
         }
         for geoJSONURL in geojsons {
-            let data = try! Data(contentsOf: geoJSONURL)
-            guard let geometries = try! Features.fromGeoJSON(data) else {
-                XCTFail("Can't extract geometry from GeoJSON data from: \(geoJSONURL.lastPathComponent)")
-                continue
+            guard let data = try? Data(contentsOf: geoJSONURL),
+                case .some(.some) = try? Features.fromGeoJSON(data) else {
+                    XCTFail("Can't extract geometry from GeoJSON data from: \(geoJSONURL.lastPathComponent)")
+                    continue
             }
-//                geometries[0].debugQuickLookObject()
-            print("\(geoJSONURL.lastPathComponent): \(geometries)")
         }
     }
 
@@ -46,13 +42,11 @@ final class GeoJSONTests: XCTestCase {
             return
         }
         for geoJSONURL in geojsons {
-            let string = try! String(contentsOf: geoJSONURL)
-            guard let geometries = try! Features.fromGeoJSON(string) else {
-                XCTFail("Can't extract geometry from GeoJSON string from: \(geoJSONURL.lastPathComponent)")
-                continue
+            guard let string = try? String(contentsOf: geoJSONURL),
+                case .some(.some) = try? Features.fromGeoJSON(string) else {
+                    XCTFail("Can't extract geometry from GeoJSON string from: \(geoJSONURL.lastPathComponent)")
+                    continue
             }
-//                geometries[0].debugQuickLookObject()
-            print("\(geoJSONURL.lastPathComponent): \(geometries)")
         }
     }
 

--- a/GEOSwiftTests/MapKitTests.swift
+++ b/GEOSwiftTests/MapKitTests.swift
@@ -12,52 +12,52 @@ import GEOSwift
 import MapKit
 
 class MapKitTests: XCTestCase {
-    
+
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
-    
+
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-    
+
     func testCreateMKPointAnnotationFromPoint() {
         var result = false
         if let point = Geometry.create("POINT(45 9)") as? Waypoint,
-            let _ = point.mapShape() as? MKPointAnnotation {
-                result = true
+            point.mapShape() as? MKPointAnnotation != nil {
+            result = true
         }
         XCTAssert(result, "MKPoint test failed")
     }
-    
+
     func testCreateMKPolylineFromLineString() {
         var result = false
         let WKT = "LINESTRING(3 4,10 50,20 25)"
         if let linestring = Geometry.create(WKT) as? LineString,
-            let _ = linestring.mapShape() as? MKPolyline {
-                result = true
+            linestring.mapShape() as? MKPolyline != nil {
+            result = true
         }
         XCTAssert(result, "MKPolyline test failed")
     }
-    
+
     func testCreateMKPolygonFromPolygon() {
         var result = false
         let WKT = "POLYGON((35 10, 45 45, 15 40, 10 20, 35 10),(20 30, 35 35, 30 20, 20 30))"
         if let polygon = Geometry.create(WKT) as? Polygon,
-            let _ = polygon.mapShape() as? MKPolygon {
-                result = true
+            polygon.mapShape() as? MKPolygon != nil {
+            result = true
         }
         XCTAssert(result, "MKPolygon test failed")
     }
-    
+
     func testCreateMKShapesCollectionFromGeometryCollection() {
         var result = false
         let WKT = "GEOMETRYCOLLECTION(POINT(4 6),LINESTRING(4 6,7 10))"
         if let geometryCollection = Geometry.create(WKT) as? GeometryCollection,
-            let _ = geometryCollection.mapShape() as? MKShapesCollection {
-                result = true
+            geometryCollection.mapShape() as? MKShapesCollection != nil {
+            result = true
         }
         XCTAssert(result, "MKShapesCollection test failed")
     }


### PR DESCRIPTION
Most of the changes are just due to long lines and extra spaces
but there were a few spots that it made more sense to refactor
than to just fix the linting:

    - Waypoint's init now checks if it can get the coord in one
      statement and defaults to origin in a single else.
    - Polygon's init is simplified to have lest nested logic
    - The private func for MKMapRect in QuickLook could have been
      refactored, but it wasn't being used so just removed it