### PR TITLE
Add files to framework target

### DIFF
--- a/GEOSwift.xcodeproj/project.pbxproj
+++ b/GEOSwift.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		335C11A98B9F38F1FD0BADB2 /* Pods_GEOSwiftTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC30B2E0DB51B308F3F23D7D /* Pods_GEOSwiftTests.framework */; };
+		4993ABEB20F4F1CF0066547D /* LinearRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4993ABE920F4F1CF0066547D /* LinearRef.swift */; };
+		4993ABEC20F4F1CF0066547D /* MiscFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4993ABEA20F4F1CF0066547D /* MiscFunctions.swift */; };
 		818D7A7F1F5F5FDF00E55FB5 /* GeoJSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 818D7A7E1F5F5FDF00E55FB5 /* GeoJSONTests.swift */; };
 		BF7C38081F82F03D001509AF /* Feature.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7C38071F82F03D001509AF /* Feature.swift */; };
 		CD20F1DD1B2830700045D8FD /* GEOSwift.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = CD2299841B10B506002C19AE /* GEOSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -61,6 +63,8 @@
 /* Begin PBXFileReference section */
 		064004E2312FE3AA64F072FA /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4929BC7A1B0BE392CD9BD0CD /* Pods-GEOSwiftTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GEOSwiftTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-GEOSwiftTests/Pods-GEOSwiftTests.debug.xcconfig"; sourceTree = "<group>"; };
+		4993ABE920F4F1CF0066547D /* LinearRef.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinearRef.swift; sourceTree = "<group>"; };
+		4993ABEA20F4F1CF0066547D /* MiscFunctions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MiscFunctions.swift; sourceTree = "<group>"; };
 		537B2F7965DB5ECD6E1CFB64 /* Pods-GEOSwiftTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GEOSwiftTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-GEOSwiftTests/Pods-GEOSwiftTests.release.xcconfig"; sourceTree = "<group>"; };
 		7D7DCB36E4FE6316A656A43A /* Pods-GEOSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GEOSwift.debug.xcconfig"; path = "Pods/Target Support Files/Pods-GEOSwift/Pods-GEOSwift.debug.xcconfig"; sourceTree = "<group>"; };
 		818D7A7E1F5F5FDF00E55FB5 /* GeoJSONTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeoJSONTests.swift; sourceTree = "<group>"; };
@@ -179,14 +183,16 @@
 		CD25D7241B2732FE008B3FB3 /* Source */ = {
 			isa = PBXGroup;
 			children = (
-				CD25D7261B2732FE008B3FB3 /* GEOS.swift */,
-				CD20F1E01B2844210045D8FD /* Geometries.swift */,
 				BF7C38071F82F03D001509AF /* Feature.swift */,
+				CD25D7251B2732FE008B3FB3 /* GeoJSON.swift */,
+				CD20F1E01B2844210045D8FD /* Geometries.swift */,
+				CD25D7261B2732FE008B3FB3 /* GEOS.swift */,
+				4993ABE920F4F1CF0066547D /* LinearRef.swift */,
+				CD25D72C1B2732FE008B3FB3 /* MapKit.swift */,
+				4993ABEA20F4F1CF0066547D /* MiscFunctions.swift */,
+				CD25D72D1B2732FE008B3FB3 /* QuickLook.swift */,
 				CD25D72E1B2732FE008B3FB3 /* SpatialAnalysis.swift */,
 				CD20F1DE1B283F580045D8FD /* SpatialRelations.swift */,
-				CD25D7251B2732FE008B3FB3 /* GeoJSON.swift */,
-				CD25D72C1B2732FE008B3FB3 /* MapKit.swift */,
-				CD25D72D1B2732FE008B3FB3 /* QuickLook.swift */,
 			);
 			name = Source;
 			path = GEOSwift;
@@ -429,8 +435,10 @@
 				CD25D7381B2732FE008B3FB3 /* SpatialAnalysis.swift in Sources */,
 				BF7C38081F82F03D001509AF /* Feature.swift in Sources */,
 				CD25D7371B2732FE008B3FB3 /* QuickLook.swift in Sources */,
+				4993ABEB20F4F1CF0066547D /* LinearRef.swift in Sources */,
 				CD25D7301B2732FE008B3FB3 /* GEOS.swift in Sources */,
 				CD20F1E11B2844210045D8FD /* Geometries.swift in Sources */,
+				4993ABEC20F4F1CF0066547D /* MiscFunctions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GEOSwift/LinearRef.swift
+++ b/GEOSwift/LinearRef.swift
@@ -14,25 +14,29 @@ public extension LineString {
 
     /// - returns: The distance of a point projected on the calling line
     public func distanceFromOriginToProjectionOfPoint(point: Waypoint) -> Double {
-        return GEOSProject_r(GEOS_HANDLE, geometry, point.geometry)
+        return GEOSProject_r(GEOS_HANDLE, storage.GEOSGeom, point.storage.GEOSGeom)
     }
 
     public func normalizedDistanceFromOriginToProjectionOfPoint(point: Waypoint) -> Double {
-        return GEOSProjectNormalized_r(GEOS_HANDLE, geometry, point.geometry)
+        return GEOSProjectNormalized_r(GEOS_HANDLE, storage.GEOSGeom, point.storage.GEOSGeom)
     }
 
     /// Return closest point to given distance within geometry
-    public func interpolatePoint(distance: Double) -> Waypoint {
-        let interpolatedPoint = GEOSInterpolate_r(GEOS_HANDLE, geometry, distance)
-        return Waypoint(GEOSGeom: interpolatedPoint!)
+    public func interpolatePoint(distance: Double) -> Waypoint? {
+        guard let interpolatedPoint = GEOSInterpolate_r(GEOS_HANDLE, storage.GEOSGeom, distance) else {
+            return nil
+        }
+        return Waypoint(storage: GeometryStorage(GEOSGeom: interpolatedPoint, parent: nil))
     }
 
-    public func interpolatePoint(fraction: Double) -> Waypoint {
-        let interpolatedPoint = GEOSInterpolateNormalized_r(GEOS_HANDLE, geometry, fraction)
-        return Waypoint(GEOSGeom: interpolatedPoint!)
+    public func interpolatePoint(fraction: Double) -> Waypoint? {
+        guard let interpolatedPoint = GEOSInterpolateNormalized_r(GEOS_HANDLE, storage.GEOSGeom, fraction) else {
+            return nil
+        }
+        return Waypoint(storage: GeometryStorage(GEOSGeom: interpolatedPoint, parent: nil))
     }
 
-    public func middlePoint() -> Waypoint {
+    public func middlePoint() -> Waypoint? {
         return self.interpolatePoint(fraction: 0.5)
     }
 }

--- a/GEOSwift/MiscFunctions.swift
+++ b/GEOSwift/MiscFunctions.swift
@@ -7,18 +7,12 @@
 
 import Foundation
 
-/**
- Misc functions
- */
-
 public extension Geometry {
-
     /// - returns: The distance between the two geometries, expressed in the SRID of the first
     func distance(geometry: Geometry) -> Double {
         var dist: Double = 0
-
-        let result = GEOSDistance_r(GEOS_HANDLE, self.geometry, geometry.geometry, &dist)
-        assert (result == 1)
+        let result = GEOSDistance_r(GEOS_HANDLE, storage.GEOSGeom, geometry.storage.GEOSGeom, &dist)
+        assert(result == 1)
         return dist
     }
 }


### PR DESCRIPTION
We found some files that get installed by cocoapods that weren't added to the framework target, so we added them. This will cause the overall coverage to decrease, but only back to the level that's actually an accurate reflection of what we had before.