### PR TITLE
Fix MKShapesCollection.boundingMapRect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Develop
 
 * [#131](https://github.com/GEOSwift/GEOSwift/pull/131) Add support for Swift Package Manager
+* [#135](https://github.com/GEOSwift/GEOSwift/pull/135) Fix MKShapesCollection.boundingMapRect
 
 ## 3.0.3
 

--- a/GEOSwift/MapKit.swift
+++ b/GEOSwift/MapKit.swift
@@ -78,11 +78,11 @@ open class MKShapesCollection: MKShape, MKOverlay {
         self.shapes = shapes
 
         if let envelope = geometryCollection.envelope() {
-            let bottomLeft = MKMapPoint(CLLocationCoordinate2D(envelope.bottomLeft))
-            let topRight = MKMapPoint(CLLocationCoordinate2D(envelope.topRight))
-            let mapRect = MKMapRect(origin: MKMapPoint(x: bottomLeft.x, y: bottomLeft.y),
-                                    size: MKMapSize(width: topRight.x - bottomLeft.x,
-                                                    height: topRight.y - bottomLeft.y))
+            let topLeft = MKMapPoint(CLLocationCoordinate2D(envelope.topLeft))
+            let bottomRight = MKMapPoint(CLLocationCoordinate2D(envelope.bottomRight))
+            let mapRect = MKMapRect(origin: MKMapPoint(x: topLeft.x, y: topLeft.y),
+                                    size: MKMapSize(width: bottomRight.x - topLeft.x,
+                                                    height: bottomRight.y - topLeft.y))
             self.boundingMapRect = mapRect
         } else {
             self.boundingMapRect = .null

--- a/GEOSwiftTests/MapKitTests.swift
+++ b/GEOSwiftTests/MapKitTests.swift
@@ -66,6 +66,22 @@ final class MapKitTests: XCTestCase {
         verifyMapShape(withGeometryCollection: MultiLineString<LinearRing>(linestrings: []))
     }
 
+    // Test case for Issue #134
+    // https://github.com/GEOSwift/GEOSwift/issues/134
+    func testMKShapesCollectionHasBoundingMapRectWithPositiveWidthAndHeight() {
+        guard let linestring = LineString(points: [Coordinate(x: -1, y: 1), Coordinate(x: 1, y: -1)]),
+            let geometryCollection = GeometryCollection(geometries: [linestring]) else {
+                XCTFail("unable to create geometries")
+                return
+        }
+        let mkShapesCollection = MKShapesCollection(geometryCollection: geometryCollection)
+
+        let boundingMapRect = mkShapesCollection.boundingMapRect
+
+        XCTAssertGreaterThan(boundingMapRect.height, 0)
+        XCTAssertGreaterThan(boundingMapRect.width, 0)
+    }
+
     func testCLLocationCoordinate2DToAndFromCoordinate() {
         let coordinate = Coordinate(x: 2, y: 1)
         let clLocationCoordinate2D = CLLocationCoordinate2D(latitude: 1, longitude: 2)


### PR DESCRIPTION
7b7e8f5 incorrectly flipped top and bottom when calculating the
MKMapRect. The MKMapPoints coordinate system increases as you go from
top to bottom, so to correctly calculate the height as a positive
number, you should subtract the top (smaller) from the bottom (larger).

Fixes #134. Thanks to @joeuelk for reporting this.