### PR TITLE
Add public init for Feature

### DIFF
--- a/GEOSwift/Feature.swift
+++ b/GEOSwift/Feature.swift
@@ -17,7 +17,7 @@ public class Feature {
     public var geometries: [Geometry]?
     public var properties: NSDictionary?
 
-    init() {
+    public init() {
         geometries = [Geometry]()
     }
 }


### PR DESCRIPTION
It will be really nice to be able to create an instance of `Feature`, adding values to it and substantially create a collection of them as `Features`.

### Scenario:

Suppose we have `[String]` of encoded polylines generated using `- (NSString *) encodedPath			
` on an instance of `GMSPath` **while recoding a transportation movement by a vehicle** . [Documentation](https://developers.google.com/maps/documentation/ios-sdk/reference/interface_g_m_s_path#a9b5b3808fbdc30e21a4b9d53e70058f7).

So we can 

1. Iterate over the `[String]`, 
2. Decode each single encoded string
3. Create an instance of `LineString` from it
4. Add the `LineString` instance to the `geometries` of `Feature`
5. Add additional values for `properties` and `id`
6. Create a `Features` inserting every single `Feature`
