### PR TITLE
Fix building on projects with spaces in path

### DIFF
--- a/GEOSwift.xcodeproj/project.pbxproj
+++ b/GEOSwift.xcodeproj/project.pbxproj
@@ -389,7 +389,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# This fixes playground unable to find the framework \ncp -R $SRCROOT/Carthage/Build/iOS/geos.framework $BUILT_PRODUCTS_DIR/geos.framework\n";
+			shellScript = "# This fixes playground unable to find the framework \ncp -R \"$SRCROOT/Carthage/Build/iOS/geos.framework\" \"$BUILT_PRODUCTS_DIR/geos.framework\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
We recently added `GEOSwift` to our project. On one of the Macs it wouldn't build. Log showed this:

```
    /bin/sh -c /Users/guido/Library/Caches/org.carthage.CarthageKit/DerivedData/10.2.1_10E1001/GEOSwift/4.1.0/Build/Intermediates.noindex/ArchiveIntermediates/GEOSwift/IntermediateBuildFilesPath/GEOSwift.build/Release-iphoneos/GEOSwift.build/Script-E2836B6C226F339E0081B1F6.sh
usage: cp [-R [-H | -L | -P]] [-fi | -n] [-apvXc] source_file target_file
       cp [-R [-H | -L | -P]] [-fi | -n] [-apvXc] source_file ... target_directory
Command PhaseScriptExecution failed with a nonzero exit code

** ARCHIVE FAILED **


The following build commands failed:
	PhaseScriptExecution Copy\ geos\ for\ Playground /Users/guido/Library/Caches/org.carthage.CarthageKit/DerivedData/10.2.1_10E1001/GEOSwift/4.1.0/Build/Intermediates.noindex/ArchiveIntermediates/GEOSwift/IntermediateBuildFilesPath/GEOSwift.build/Release-iphoneos/GEOSwift.build/Script-E2836B6C226F339E0081B1F6.sh
(1 failure)
```

After debugging I figured out it was because of spaces in the path of the Xcode project. This changes resolves this issue.