### PR TITLE
Use geos impls in LineStringConvertible methods

### DIFF
--- a/Sources/GEOSwift/GEOSwiftError.swift
+++ b/Sources/GEOSwift/GEOSwiftError.swift
@@ -7,6 +7,5 @@ public enum GEOSwiftError: Error, Equatable {
     case ringNotClosed
     case tooFewRings
     case invalidFeatureId
-    case lengthIsZero
     case unexpectedEnvelopeResult(Geometry)
 }

--- a/Tests/GEOSwiftTests/GEOS/LineStringConvertible+GEOSTests.swift
+++ b/Tests/GEOSwiftTests/GEOS/LineStringConvertible+GEOSTests.swift
@@ -123,34 +123,20 @@ final class LineStringConvertible_GEOSTests: XCTestCase {
         XCTAssertEqual(try? linearRing.normalizedDistanceFromStart(toProjectionOf: point), 1 / 8)
     }
 
-    func testNormalizedDistanceFromStartToProjectionOfPointLineLengthZero_LineString() {
+    func testNormalizedDistanceFromStartToProjectionOfPointLineLengthZero_LineString() throws {
         let lineString = try! LineString(points: Array(repeating: Point(x: 0, y: 0), count: 2))
 
         let point = Point(x: 0, y: 0)
 
-        do {
-            _ = try lineString.normalizedDistanceFromStart(toProjectionOf: point)
-            XCTFail("Expected call to throw, but it did not.")
-        } catch GEOSwiftError.lengthIsZero {
-            // Pass
-        } catch {
-            XCTFail("Threw unexpected error: \(error)")
-        }
+        XCTAssertEqual(try lineString.normalizedDistanceFromStart(toProjectionOf: point), 0)
     }
 
-    func testNormalizedDistanceFromStartToProjectionOfPointLineLengthZero_LinearRing() {
+    func testNormalizedDistanceFromStartToProjectionOfPointLineLengthZero_LinearRing() throws {
         let linearRing = try! Polygon.LinearRing(points: Array(repeating: Point(x: 0, y: 0), count: 4))
 
         let point = Point(x: 0, y: 0)
 
-        do {
-            _ = try linearRing.normalizedDistanceFromStart(toProjectionOf: point)
-            XCTFail("Expected call to throw, but it did not.")
-        } catch GEOSwiftError.lengthIsZero {
-            // Pass
-        } catch {
-            XCTFail("Threw unexpected error: \(error)")
-        }
+        XCTAssertEqual(try linearRing.normalizedDistanceFromStart(toProjectionOf: point), 0)
     }
 
     func testInterpolatedPointWithDistance_LineString() {


### PR DESCRIPTION
* Updates normalizedDistanceFromStart(toProjectionOf:). The geos impl
returns 0 for 0-length lines, whereas the old GEOSwift impl threw
GEOSwiftError.lengthIsZero, which has now been removed.

* Updates interpolatedPoint(withFraction:)

Fixes #220