### PR TITLE
Make GEOContext and geoObject methods public to use other C methods from geos library

### DIFF
--- a/Sources/GEOSwift/GEOS/GEOSContext.swift
+++ b/Sources/GEOSwift/GEOS/GEOSContext.swift
@@ -1,10 +1,10 @@
 import geos
 
-final class GEOSContext {
-    let handle: GEOSContextHandle_t
-    fileprivate(set) var errors = [String]()
+public final class GEOSContext {
+    public let handle: GEOSContextHandle_t
+    public fileprivate(set) var errors = [String]()
 
-    init() throws {
+    public init() throws {
         guard let handle = GEOS_init_r() else {
             throw GEOSError.unableToCreateContext
         }

--- a/Sources/GEOSwift/GEOS/GEOSObject.swift
+++ b/Sources/GEOSwift/GEOS/GEOSObject.swift
@@ -15,13 +15,13 @@ protocol GEOSObjectInitializable {
     init(geosObject: GEOSObject) throws
 }
 
-protocol GEOSObjectConvertible {
+public protocol GEOSObjectConvertible {
     func geosObject(with context: GEOSContext) throws -> GEOSObject
 }
 
-final class GEOSObject {
+public final class GEOSObject {
     let context: GEOSContext
-    let pointer: OpaquePointer
+    public let pointer: OpaquePointer
     var parent: GEOSObject? {
         didSet {
             // make sure we're not mixing objects from different contexts

--- a/Sources/GEOSwift/GEOS/Geometry+GEOS.swift
+++ b/Sources/GEOSwift/GEOS/Geometry+GEOS.swift
@@ -25,7 +25,7 @@ extension Geometry: GEOSObjectInitializable {
 }
 
 extension Geometry: GEOSObjectConvertible {
-    func geosObject(with context: GEOSContext) throws -> GEOSObject {
+    public func geosObject(with context: GEOSContext) throws -> GEOSObject {
         switch self {
         case let .point(point):
             return try point.geosObject(with: context)

--- a/Sources/GEOSwift/GEOS/GeometryCollection+GEOS.swift
+++ b/Sources/GEOSwift/GEOS/GeometryCollection+GEOS.swift
@@ -10,7 +10,7 @@ extension GeometryCollection: GEOSObjectInitializable {
 }
 
 extension GeometryCollection: GEOSObjectConvertible {
-    func geosObject(with context: GEOSContext) throws -> GEOSObject {
+    public func geosObject(with context: GEOSContext) throws -> GEOSObject {
         try makeGEOSCollection(with: context, geometries: geometries, type: GEOS_GEOMETRYCOLLECTION)
     }
 }

--- a/Sources/GEOSwift/GEOS/LineString+GEOS.swift
+++ b/Sources/GEOSwift/GEOS/LineString+GEOS.swift
@@ -10,7 +10,7 @@ extension LineString: GEOSObjectInitializable {
 }
 
 extension LineString: GEOSObjectConvertible {
-    func geosObject(with context: GEOSContext) throws -> GEOSObject {
+    public func geosObject(with context: GEOSContext) throws -> GEOSObject {
         try makeGEOSObject(with: context, points: points) { (context, sequence) in
             GEOSGeom_createLineString_r(context.handle, sequence)
         }

--- a/Sources/GEOSwift/GEOS/MultiLineString+GEOS.swift
+++ b/Sources/GEOSwift/GEOS/MultiLineString+GEOS.swift
@@ -10,7 +10,7 @@ extension MultiLineString: GEOSObjectInitializable {
 }
 
 extension MultiLineString: GEOSObjectConvertible {
-    func geosObject(with context: GEOSContext) throws -> GEOSObject {
+    public func geosObject(with context: GEOSContext) throws -> GEOSObject {
         try makeGEOSCollection(with: context, geometries: lineStrings, type: GEOS_MULTILINESTRING)
     }
 }

--- a/Sources/GEOSwift/GEOS/MultiPoint+GEOS.swift
+++ b/Sources/GEOSwift/GEOS/MultiPoint+GEOS.swift
@@ -10,7 +10,7 @@ extension MultiPoint: GEOSObjectInitializable {
 }
 
 extension MultiPoint: GEOSObjectConvertible {
-    func geosObject(with context: GEOSContext) throws -> GEOSObject {
+    public func geosObject(with context: GEOSContext) throws -> GEOSObject {
         try makeGEOSCollection(with: context, geometries: points, type: GEOS_MULTIPOINT)
     }
 }

--- a/Sources/GEOSwift/GEOS/MultiPolygon+GEOS.swift
+++ b/Sources/GEOSwift/GEOS/MultiPolygon+GEOS.swift
@@ -10,7 +10,7 @@ extension MultiPolygon: GEOSObjectInitializable {
 }
 
 extension MultiPolygon: GEOSObjectConvertible {
-    func geosObject(with context: GEOSContext) throws -> GEOSObject {
+    public func geosObject(with context: GEOSContext) throws -> GEOSObject {
         try makeGEOSCollection(with: context, geometries: polygons, type: GEOS_MULTIPOLYGON)
     }
 }

--- a/Sources/GEOSwift/GEOS/Point+GEOS.swift
+++ b/Sources/GEOSwift/GEOS/Point+GEOS.swift
@@ -26,7 +26,7 @@ extension Point: GEOSObjectInitializable {
 }
 
 extension Point: GEOSObjectConvertible {
-    func geosObject(with context: GEOSContext) throws -> GEOSObject {
+    public func geosObject(with context: GEOSContext) throws -> GEOSObject {
         try makeGEOSObject(with: context, points: [self]) { (context, sequence) in
             GEOSGeom_createPoint_r(context.handle, sequence)
         }

--- a/Sources/GEOSwift/GEOS/Polygon+GEOS.swift
+++ b/Sources/GEOSwift/GEOS/Polygon+GEOS.swift
@@ -10,7 +10,7 @@ extension Polygon.LinearRing: GEOSObjectInitializable {
 }
 
 extension Polygon.LinearRing: GEOSObjectConvertible {
-    func geosObject(with context: GEOSContext) throws -> GEOSObject {
+    public func geosObject(with context: GEOSContext) throws -> GEOSObject {
         try makeGEOSObject(with: context, points: points) { (context, sequence) in
             GEOSGeom_createLinearRing_r(context.handle, sequence)
         }
@@ -47,7 +47,7 @@ extension Polygon: GEOSObjectInitializable {
 }
 
 extension Polygon: GEOSObjectConvertible {
-    func geosObject(with context: GEOSContext) throws -> GEOSObject {
+    public func geosObject(with context: GEOSContext) throws -> GEOSObject {
         let exterior = try self.exterior.geosObject(with: context)
         let holes = try self.holes.map { try $0.geosObject(with: context) }
         let holesArray = UnsafeMutablePointer<OpaquePointer?>.allocate(capacity: holes.count)


### PR DESCRIPTION
To implement `hausdorffDistance` method some of the classes and methods are required to be in the public scope.