### PR TITLE
Update to GEOS 3.13 (aka GEOSwift/geos 9.0.0); Update CI Environments; Update Apple Platform Deployment Targets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,9 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v3
-      - name: Swiftlint
+      - name: Install SwiftLint
+        run: brew install swiftlint
+      - name: SwiftLint
         run: swiftlint --strict
   podspec:
     name: Lint Podspec for ${{ matrix.platform }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,16 +16,16 @@ jobs:
         run: brew install swiftlint
       - name: SwiftLint
         run: swiftlint --strict
-  podspec:
-    name: Lint Podspec for ${{ matrix.platform }}
-    runs-on: macos-14
-    strategy:
-      matrix:
-        platform: [ios, osx, tvos]
-    steps:
-      - uses: actions/checkout@v3
-      - name: Lint Podspec
-        run: pod lib lint --platforms=${{ matrix.platform }}
+  # podspec:
+  #   name: Lint Podspec for ${{ matrix.platform }}
+  #   runs-on: macos-14
+  #   strategy:
+  #     matrix:
+  #       platform: [ios, osx, tvos]
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Lint Podspec
+  #       run: pod lib lint --platforms=${{ matrix.platform }}
   xcodebuild:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,7 @@ jobs:
             -scheme GEOSwift \
             -sdk "${{ matrix.sdk }}" \
             -destination "${{ matrix.destination }}" \
+            -testPlan GEOSwift
             clean test | xcpretty -c;
   swift-cli-macos:
     name: "swift-cli (${{ matrix.os }}, Xcode ${{matrix.xcode-version}})"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,20 +3,20 @@ name: GEOSwift
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   swiftlint:
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v3
       - name: Swiftlint
         run: swiftlint --strict
   podspec:
     name: Lint Podspec for ${{ matrix.platform }}
-    runs-on: macos-12
+    runs-on: macos-14
     strategy:
       matrix:
         platform: [ios, osx, tvos]
@@ -30,46 +30,26 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: "xcodebuild (iOS 16.2, Xcode 14.2)"
-            os: macos-12
-            xcode-version: "14.2"
-            sdk: iphonesimulator16.2
-            destination: "platform=iOS Simulator,OS=16.2,name=iPhone 14"
-          - name: "xcodebuild (tvOS 16.1, Xcode 14.2)"
-            os: macos-12
-            xcode-version: "14.2"
-            sdk: appletvsimulator16.1
-            destination: "platform=tvOS Simulator,OS=16.1,name=Apple TV"
-          - name: "xcodebuild (macOS 13.1, Xcode 14.2)"
-            os: macos-12
-            xcode-version: "14.2"
-            sdk: macosx13.1
+          - name: "xcodebuild (iOS 17.5, Xcode 15.4)"
+            os: macos-14
+            xcode-version: "15.4"
+            sdk: iphonesimulator17.5
+            destination: "platform=iOS Simulator,OS=17.5,name=iPhone 15"
+          - name: "xcodebuild (tvOS 17.5, Xcode 15.4)"
+            os: macos-14
+            xcode-version: "15.4"
+            sdk: appletvsimulator17.5
+            destination: "platform=tvOS Simulator,OS=17.5,name=Apple TV"
+          - name: "xcodebuild (macOS 14.5, Xcode 15.4)"
+            os: macos-14
+            xcode-version: "15.4"
+            sdk: macosx14.5
             destination: "platform=OS X"
-          - name: "xcodebuild (watchOS 9.1, Xcode 14.2)"
-            os: macos-12
-            xcode-version: "14.2"
-            sdk: watchsimulator9.1
-            destination: "platform=watchOS Simulator,OS=9.1,name=Apple Watch Series 8 (45mm)"
-          - name: "xcodebuild (iOS 15.2, Xcode 13.2.1)"
-            os: macos-11
-            xcode-version: "13.2.1"
-            sdk: iphonesimulator15.2
-            destination: "platform=iOS Simulator,OS=15.2,name=iPhone 13"
-          - name: "xcodebuild (tvOS 15.2, Xcode 13.2.1)"
-            os: macos-11
-            xcode-version: "13.2.1"
-            sdk: appletvsimulator15.2
-            destination: "platform=tvOS Simulator,OS=15.2,name=Apple TV"
-          - name: "xcodebuild (macOS 12.1, Xcode 13.2.1)"
-            os: macos-11
-            xcode-version: "13.2.1"
-            sdk: macosx12.1
-            destination: "platform=OS X"
-          - name: "xcodebuild (watchOS 8.3, Xcode 13.2.1)"
-            os: macos-11
-            xcode-version: "13.2.1"
-            sdk: watchos8.3
-            destination: "platform=watchOS Simulator,OS=8.3,name=Apple Watch Series 7 - 45mm"
+          - name: "xcodebuild (watchOS 10.5, Xcode 15.4)"
+            os: macos-14
+            xcode-version: "15.4"
+            sdk: watchsimulator10.5
+            destination: "platform=watchOS Simulator,OS=10.5,name=Apple Watch Series 9 (45mm)"
     steps:
       - uses: actions/checkout@v3
       - name: Select Xcode Version
@@ -89,10 +69,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-11
-            xcode-version: "13.2.1"
-          - os: macos-12
-            xcode-version: "14.2"
+          - os: macos-14
+            xcode-version: "15.4"
     steps:
       - uses: actions/checkout@v3
       - name: Select Xcode Version
@@ -105,7 +83,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: Build & Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,6 @@ jobs:
             -scheme GEOSwift \
             -sdk "${{ matrix.sdk }}" \
             -destination "${{ matrix.destination }}" \
-            -testPlan GEOSwift \
             clean test | xcpretty -c;
   swift-cli-macos:
     name: "swift-cli (${{ matrix.os }}, Xcode ${{matrix.xcode-version}})"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
         platform: [ios, osx, tvos]
     steps:
       - uses: actions/checkout@v3
+      - name: Update CocoaPods Specs
+        run: pod repo update
       - name: Lint Podspec
         run: pod lib lint --platforms=${{ matrix.platform }}
   # xcodebuild:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,85 +8,85 @@ on:
     branches: [main]
 
 jobs:
-  swiftlint:
-    runs-on: macos-14
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install SwiftLint
-        run: brew install swiftlint
-      - name: SwiftLint
-        run: swiftlint --strict
-  # podspec:
-  #   name: Lint Podspec for ${{ matrix.platform }}
+  # swiftlint:
   #   runs-on: macos-14
-  #   strategy:
-  #     matrix:
-  #       platform: [ios, osx, tvos]
   #   steps:
   #     - uses: actions/checkout@v3
-  #     - name: Lint Podspec
-  #       run: pod lib lint --platforms=${{ matrix.platform }}
-  xcodebuild:
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
+  #     - name: Install SwiftLint
+  #       run: brew install swiftlint
+  #     - name: SwiftLint
+  #       run: swiftlint --strict
+  podspec:
+    name: Lint Podspec for ${{ matrix.platform }}
+    runs-on: macos-14
     strategy:
       matrix:
-        include:
-          - name: "xcodebuild (iOS 17.5, Xcode 15.4)"
-            os: macos-14
-            xcode-version: "15.4"
-            sdk: iphonesimulator17.5
-            destination: "platform=iOS Simulator,OS=17.5,name=iPhone 15"
-          - name: "xcodebuild (tvOS 17.5, Xcode 15.4)"
-            os: macos-14
-            xcode-version: "15.4"
-            sdk: appletvsimulator17.5
-            destination: "platform=tvOS Simulator,OS=17.5,name=Apple TV"
-          - name: "xcodebuild (macOS 14.5, Xcode 15.4)"
-            os: macos-14
-            xcode-version: "15.4"
-            sdk: macosx14.5
-            destination: "platform=OS X"
-          - name: "xcodebuild (watchOS 10.5, Xcode 15.4)"
-            os: macos-14
-            xcode-version: "15.4"
-            sdk: watchsimulator10.5
-            destination: "platform=watchOS Simulator,OS=10.5,name=Apple Watch Series 9 (45mm)"
+        platform: [ios, osx, tvos]
     steps:
       - uses: actions/checkout@v3
-      - name: Select Xcode Version
-        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer
-      - name: Install xcpretty
-        run: gem install xcpretty
-      - name: Build & Test
-        run: |
-          set -o pipefail && xcodebuild \
-            -scheme GEOSwift \
-            -sdk "${{ matrix.sdk }}" \
-            -destination "${{ matrix.destination }}" \
-            clean test | xcpretty -c;
-  swift-cli-macos:
-    name: "swift-cli (${{ matrix.os }}, Xcode ${{matrix.xcode-version}})"
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - os: macos-14
-            xcode-version: "15.4"
-    steps:
-      - uses: actions/checkout@v3
-      - name: Select Xcode Version
-        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer
-      - name: Build & Test
-        run: swift test
-  swift-cli-linux:
-    name: "swift-cli (${{ matrix.os }})"
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v3
-      - name: Build & Test
-        run: swift test
+      - name: Lint Podspec
+        run: pod lib lint --platforms=${{ matrix.platform }}
+  # xcodebuild:
+  #   name: ${{ matrix.name }}
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       include:
+  #         - name: "xcodebuild (iOS 17.5, Xcode 15.4)"
+  #           os: macos-14
+  #           xcode-version: "15.4"
+  #           sdk: iphonesimulator17.5
+  #           destination: "platform=iOS Simulator,OS=17.5,name=iPhone 15"
+  #         - name: "xcodebuild (tvOS 17.5, Xcode 15.4)"
+  #           os: macos-14
+  #           xcode-version: "15.4"
+  #           sdk: appletvsimulator17.5
+  #           destination: "platform=tvOS Simulator,OS=17.5,name=Apple TV"
+  #         - name: "xcodebuild (macOS 14.5, Xcode 15.4)"
+  #           os: macos-14
+  #           xcode-version: "15.4"
+  #           sdk: macosx14.5
+  #           destination: "platform=OS X"
+  #         - name: "xcodebuild (watchOS 10.5, Xcode 15.4)"
+  #           os: macos-14
+  #           xcode-version: "15.4"
+  #           sdk: watchsimulator10.5
+  #           destination: "platform=watchOS Simulator,OS=10.5,name=Apple Watch Series 9 (45mm)"
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Select Xcode Version
+  #       run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer
+  #     - name: Install xcpretty
+  #       run: gem install xcpretty
+  #     - name: Build & Test
+  #       run: |
+  #         set -o pipefail && xcodebuild \
+  #           -scheme GEOSwift \
+  #           -sdk "${{ matrix.sdk }}" \
+  #           -destination "${{ matrix.destination }}" \
+  #           clean test | xcpretty -c;
+  # swift-cli-macos:
+  #   name: "swift-cli (${{ matrix.os }}, Xcode ${{matrix.xcode-version}})"
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       include:
+  #         - os: macos-14
+  #           xcode-version: "15.4"
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Select Xcode Version
+  #       run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer
+  #     - name: Build & Test
+  #       run: swift test
+  # swift-cli-linux:
+  #   name: "swift-cli (${{ matrix.os }})"
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       include:
+  #         - os: ubuntu-24.04
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Build & Test
+  #       run: swift test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,14 +8,14 @@ on:
     branches: [main]
 
 jobs:
-  # swiftlint:
-  #   runs-on: macos-14
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Install SwiftLint
-  #       run: brew install swiftlint
-  #     - name: SwiftLint
-  #       run: swiftlint --strict
+  swiftlint:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install SwiftLint
+        run: brew install swiftlint
+      - name: SwiftLint
+        run: swiftlint --strict
   podspec:
     name: Lint Podspec for ${{ matrix.platform }}
     runs-on: macos-14
@@ -28,67 +28,67 @@ jobs:
         run: pod repo update
       - name: Lint Podspec
         run: pod lib lint --platforms=${{ matrix.platform }}
-  # xcodebuild:
-  #   name: ${{ matrix.name }}
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       include:
-  #         - name: "xcodebuild (iOS 17.5, Xcode 15.4)"
-  #           os: macos-14
-  #           xcode-version: "15.4"
-  #           sdk: iphonesimulator17.5
-  #           destination: "platform=iOS Simulator,OS=17.5,name=iPhone 15"
-  #         - name: "xcodebuild (tvOS 17.5, Xcode 15.4)"
-  #           os: macos-14
-  #           xcode-version: "15.4"
-  #           sdk: appletvsimulator17.5
-  #           destination: "platform=tvOS Simulator,OS=17.5,name=Apple TV"
-  #         - name: "xcodebuild (macOS 14.5, Xcode 15.4)"
-  #           os: macos-14
-  #           xcode-version: "15.4"
-  #           sdk: macosx14.5
-  #           destination: "platform=OS X"
-  #         - name: "xcodebuild (watchOS 10.5, Xcode 15.4)"
-  #           os: macos-14
-  #           xcode-version: "15.4"
-  #           sdk: watchsimulator10.5
-  #           destination: "platform=watchOS Simulator,OS=10.5,name=Apple Watch Series 9 (45mm)"
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Select Xcode Version
-  #       run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer
-  #     - name: Install xcpretty
-  #       run: gem install xcpretty
-  #     - name: Build & Test
-  #       run: |
-  #         set -o pipefail && xcodebuild \
-  #           -scheme GEOSwift \
-  #           -sdk "${{ matrix.sdk }}" \
-  #           -destination "${{ matrix.destination }}" \
-  #           clean test | xcpretty -c;
-  # swift-cli-macos:
-  #   name: "swift-cli (${{ matrix.os }}, Xcode ${{matrix.xcode-version}})"
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       include:
-  #         - os: macos-14
-  #           xcode-version: "15.4"
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Select Xcode Version
-  #       run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer
-  #     - name: Build & Test
-  #       run: swift test
-  # swift-cli-linux:
-  #   name: "swift-cli (${{ matrix.os }})"
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       include:
-  #         - os: ubuntu-24.04
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Build & Test
-  #       run: swift test
+  xcodebuild:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - name: "xcodebuild (iOS 17.5, Xcode 15.4)"
+            os: macos-14
+            xcode-version: "15.4"
+            sdk: iphonesimulator17.5
+            destination: "platform=iOS Simulator,OS=17.5,name=iPhone 15"
+          - name: "xcodebuild (tvOS 17.5, Xcode 15.4)"
+            os: macos-14
+            xcode-version: "15.4"
+            sdk: appletvsimulator17.5
+            destination: "platform=tvOS Simulator,OS=17.5,name=Apple TV"
+          - name: "xcodebuild (macOS 14.5, Xcode 15.4)"
+            os: macos-14
+            xcode-version: "15.4"
+            sdk: macosx14.5
+            destination: "platform=OS X"
+          - name: "xcodebuild (watchOS 10.5, Xcode 15.4)"
+            os: macos-14
+            xcode-version: "15.4"
+            sdk: watchsimulator10.5
+            destination: "platform=watchOS Simulator,OS=10.5,name=Apple Watch Series 9 (45mm)"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Select Xcode Version
+        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer
+      - name: Install xcpretty
+        run: gem install xcpretty
+      - name: Build & Test
+        run: |
+          set -o pipefail && xcodebuild \
+            -scheme GEOSwift \
+            -sdk "${{ matrix.sdk }}" \
+            -destination "${{ matrix.destination }}" \
+            clean test | xcpretty -c;
+  swift-cli-macos:
+    name: "swift-cli (${{ matrix.os }}, Xcode ${{matrix.xcode-version}})"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-14
+            xcode-version: "15.4"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Select Xcode Version
+        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer
+      - name: Build & Test
+        run: swift test
+  swift-cli-linux:
+    name: "swift-cli (${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build & Test
+        run: swift test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
             -scheme GEOSwift \
             -sdk "${{ matrix.sdk }}" \
             -destination "${{ matrix.destination }}" \
-            -testPlan GEOSwift
+            -testPlan GEOSwift \
             clean test | xcpretty -c;
   swift-cli-macos:
     name: "swift-cli (${{ matrix.os }}, Xcode ${{matrix.xcode-version}})"

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,3 @@ Carthage/Build
 # Swift Package Manager
 
 .build/
-.swiftpm/

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/GEOSwift.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/GEOSwift.xcscheme
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "GEOSwift"
+               BuildableName = "GEOSwift"
+               BlueprintName = "GEOSwift"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:GEOSwift.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "GEOSwiftTests"
+               BuildableName = "GEOSwiftTests"
+               BlueprintName = "GEOSwiftTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "GEOSwift"
+            BuildableName = "GEOSwift"
+            BlueprintName = "GEOSwift"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 11.0.0
+
+* [#284](https://github.com/GEOSwift/GEOSwift/pull/284) Update GEOS, CI, and Apple Platform Versions
+
 ## 10.3.0
 
 * [#281](https://github.com/GEOSwift/GEOSwift/pull/281) Add `GeometryConvertible.lineMergeDirected()` and `GeometryConvertible.lineMerge()`

--- a/GEOSwift.podspec
+++ b/GEOSwift.podspec
@@ -24,5 +24,5 @@ Pod::Spec.new do |s|
     tag: s.version,
   }
   s.source_files = 'Sources/**/*.swift'
-  s.dependency 'geos', :git => 'https://github.com/GEOSwift/geos.git', :branch => 'geos-3.13'
+  s.dependency 'geos', '~> 9.0'
 end

--- a/GEOSwift.podspec
+++ b/GEOSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'GEOSwift'
-  s.version = '10.3.0'
+  s.version = '11.0.0'
   s.swift_version = '5.9'
   s.cocoapods_version = '~> 1.10'
   s.summary = 'The Swift Geometry Engine.'

--- a/GEOSwift.podspec
+++ b/GEOSwift.podspec
@@ -15,12 +15,10 @@ Pod::Spec.new do |s|
     file: 'LICENSE'
   }
   s.authors = 'Andrea Cremaschi', 'Andrew Hershberger', 'Virgilio Favero Neto'
-  s.platforms = {
-    ios: '12.0',
-    osx: '10.13',
-    tvos: '12.0',
-    watchos: '4.0',
-  }
+  s.ios.deployment_target = '12.0'
+  s.osx.deployment_target = '10.13'
+  s.tvos.deployment_target = '12.0'
+  s.watchos.deployment_target = '4.0'
   s.source = {
     git: 'https://github.com/GEOSwift/GEOSwift.git',
     tag: s.version,

--- a/GEOSwift.podspec
+++ b/GEOSwift.podspec
@@ -24,5 +24,5 @@ Pod::Spec.new do |s|
     tag: s.version,
   }
   s.source_files = 'Sources/**/*.swift'
-  s.dependency 'geos', '~> 8.1'
+  s.dependency 'geos', :git => 'https://github.com/GEOSwift/geos.git', :branch => 'geos-3.13'
 end

--- a/GEOSwift.podspec
+++ b/GEOSwift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = 'GEOSwift'
   s.version = '10.3.0'
-  s.swift_version = '5.5'
+  s.swift_version = '5.9'
   s.cocoapods_version = '~> 1.10'
   s.summary = 'The Swift Geometry Engine.'
   s.description  = <<~DESC
@@ -16,10 +16,10 @@ Pod::Spec.new do |s|
   }
   s.authors = 'Andrea Cremaschi', 'Andrew Hershberger', 'Virgilio Favero Neto'
   s.platforms = {
-    ios: '9.0',
-    osx: '10.9',
-    tvos: '9.0',
-    watchos: '2.0',
+    ios: '12.0',
+    osx: '10.13',
+    tvos: '12.0',
+    watchos: '4.0',
   }
   s.source = {
     git: 'https://github.com/GEOSwift/GEOSwift.git',

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GEOSwift/geos.git",
       "state" : {
-        "branch" : "geos-3.13",
-        "revision" : "1db87a4d904103400d9e7f6d109f4039dd879047"
+        "revision" : "4d8af495e7507f48f1ae9104102debdd2043917b",
+        "version" : "9.0.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,16 +1,14 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "geos",
-        "repositoryURL": "https://github.com/GEOSwift/geos.git",
-        "state": {
-          "branch": null,
-          "revision": "f510e634c822116fca615064d889300dba40d761",
-          "version": "8.1.0"
-        }
+  "pins" : [
+    {
+      "identity" : "geos",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/GEOSwift/geos.git",
+      "state" : {
+        "branch" : "geos-3.13",
+        "revision" : "1db87a4d904103400d9e7f6d109f4039dd879047"
       }
-    ]
-  },
-  "version": 1
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "GEOSwift", targets: ["GEOSwift"])
     ],
     dependencies: [
-        .package(url: "https://github.com/GEOSwift/geos.git", branch: "geos-3.13")
+        .package(url: "https://github.com/GEOSwift/geos.git", from: "9.0.0")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "GEOSwift", targets: ["GEOSwift"])
     ],
     dependencies: [
-        .package(url: "https://github.com/GEOSwift/geos.git", from: "8.1.0")
+        .package(url: "https://github.com/GEOSwift/geos.git", branch: "geos-3.13")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,9 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.9
 import PackageDescription
 
 let package = Package(
     name: "GEOSwift",
-    platforms: [.iOS(.v9), .macOS("10.9"), .tvOS(.v9), .watchOS(.v2)],
+    platforms: [.iOS(.v12), .macOS(.v10_13), .tvOS(.v12), .watchOS(.v4)],
     products: [
         .library(name: "GEOSwift", targets: ["GEOSwift"])
     ],

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ at least controversial. Use of geos without dynamic linking is discouraged.
 
 1. Update the top-level dependencies in your `Package.swift` to include:
 
-        .package(url: "https://github.com/GEOSwift/GEOSwift.git", from: "10.3.0")
+        .package(url: "https://github.com/GEOSwift/GEOSwift.git", from: "11.0.0")
 
 2. Update the target dependencies in your `Package.swift` to include
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ migrating from version 4, see [VERSION_5.md](VERSION_5.md).
 
 ## Requirements
 
-* iOS 9.0+, tvOS 9.0+, macOS 10.9+, watchOS 2.0+ (Swift Package Manager, CocoaPods)
+* iOS 12.0+, tvOS 12.0+, macOS 10.13+, watchOS 4.0+ (Swift Package Manager, CocoaPods)
 * Linux (Swift Package Manager)
-* Swift 5.5
+* Swift 5.9
 
 > GEOS is licensed under LGPL 2.1 and its compatibility with static linking is
 at least controversial. Use of geos without dynamic linking is discouraged.

--- a/Tests/GEOSwiftTests/GEOS/WKBTests.swift
+++ b/Tests/GEOSwiftTests/GEOS/WKBTests.swift
@@ -53,7 +53,7 @@ final class WKBTests: XCTestCase {
     }
 
     func verifyInitWithInvalidWKB<T>(type: T.Type, line: UInt = #line) where T: WKBInitializable {
-        let invalidWKB = "invalid".data(using: .utf8)!
+        let invalidWKB = Data("invalid".utf8)
         do {
             _ = try T(wkb: invalidWKB)
             XCTFail("Unexpected success", line: line)

--- a/Tests/GEOSwiftTests/GEOS/WKTTests.swift
+++ b/Tests/GEOSwiftTests/GEOS/WKTTests.swift
@@ -234,21 +234,21 @@ final class WKTTests: XCTestCase {
             wktConvertible: point,
             trim: true,
             roundingPrecision: -1,
-            expectedWKT: "POINT (0.1 0.000000123456)")
+            expectedWKT: "POINT (0.1 1.23456e-7)")
         verifyWKTOptions(
             wktConvertible: point,
             trim: true,
             roundingPrecision: 0,
-            expectedWKT: "POINT (0 0)")
+            expectedWKT: "POINT (0.1 1e-7)")
         verifyWKTOptions(
             wktConvertible: point,
             trim: true,
             roundingPrecision: 1,
-            expectedWKT: "POINT (0.1 0)")
+            expectedWKT: "POINT (0.1 1.2e-7)")
         verifyWKTOptions(
             wktConvertible: point,
             trim: true,
             roundingPrecision: 5,
-            expectedWKT: "POINT (0.1 0)")
+            expectedWKT: "POINT (0.1 1.23456e-7)")
     }
 }


### PR DESCRIPTION
* CI workflows were out of date, so this PR updates them to target newer environments
* Also updates to the latest geos
* And bumps minimum deployment targets for Apple platforms to match those supported by Xcode 15

Fixes #279 
Fixes #275 