### PR TITLE
Fix crash in polygonize()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 11.0.0
 
 * [#284](https://github.com/GEOSwift/GEOSwift/pull/284) Update GEOS, CI, and Apple Platform Versions
+* [#285](https://github.com/GEOSwift/GEOSwift/pull/285) Fix crash in polygonize()
 
 ## 10.3.0
 

--- a/Sources/GEOSwift/GEOS/GeometryConvertible+GEOS.swift
+++ b/Sources/GEOSwift/GEOS/GeometryConvertible+GEOS.swift
@@ -551,11 +551,11 @@ public extension Collection where Element: GeometryConvertible {
     func polygonize() throws -> GeometryCollection {
         let context = try GEOSContext()
         let geosObjects = try map { try $0.geometry.geosObject(with: context) }
-        guard let pointer = GEOSPolygonize_r(
-            context.handle,
-            geosObjects.map { $0.pointer },
-            UInt32(geosObjects.count)) else {
-                throw GEOSError.libraryError(errorMessages: context.errors)
+        let pointer = withExtendedLifetime(geosObjects) { geosObjects in
+            GEOSPolygonize_r(context.handle, geosObjects.map { $0.pointer }, UInt32(geosObjects.count))
+        }
+        guard let pointer else {
+            throw GEOSError.libraryError(errorMessages: context.errors)
         }
         return try GeometryCollection(geosObject: GEOSObject(context: context, pointer: pointer))
     }


### PR DESCRIPTION
* Crash occurred due to `geosObjects` getting deinited too soon in release mode. Fixed by using `withExtendedLifetime(_:_:)`
* Fixes #280