### PR TITLE
Add Z coordinate to Point

### DIFF
--- a/Sources/GEOSwift/Codable/Point+Codable.swift
+++ b/Sources/GEOSwift/Codable/Point+Codable.swift
@@ -3,13 +3,16 @@ extension Point: CodableGeometry {
     static let geoJSONType = GeoJSONType.point
 
     var coordinates: [Double] {
-        [x, y]
+        z == nil ? [x, y] : [x, y, z!]
     }
 
     init(coordinates: [Double]) throws {
         guard coordinates.count >= 2 else {
             throw GEOSwiftError.invalidCoordinates
         }
-        self.init(x: coordinates[0], y: coordinates[1])
+        
+        let z = coordinates.count >= 3 ? coordinates[2] : nil
+
+        self.init(x: coordinates[0], y: coordinates[1], z: z)
     }
 }

--- a/Sources/GEOSwift/Core Types/Point.swift
+++ b/Sources/GEOSwift/Core Types/Point.swift
@@ -1,9 +1,11 @@
 public struct Point: Hashable, Sendable {
     public var x: Double
     public var y: Double
+    public var z: Double?
 
-    public init(x: Double, y: Double) {
+    public init(x: Double, y: Double, z: Double? = nil) {
         self.x = x
         self.y = y
+        self.z = z
     }
 }

--- a/Sources/GEOSwift/GEOS/Point+GEOS.swift
+++ b/Sources/GEOSwift/GEOS/Point+GEOS.swift
@@ -16,12 +16,23 @@ extension Point: GEOSObjectInitializable {
         }
         var x: Double = 0
         var y: Double = 0
+        var z: Double?
+        let hasZ = GEOSGeom_getCoordinateDimension_r(geosObject.context.handle, geosObject.pointer) > 2
         // returns 1 on success
         guard GEOSGeomGetX_r(geosObject.context.handle, geosObject.pointer, &x) == 1,
             GEOSGeomGetY_r(geosObject.context.handle, geosObject.pointer, &y) == 1 else {
                 throw GEOSError.libraryError(errorMessages: geosObject.context.errors)
         }
-        self.init(x: x, y: y)
+        
+        if hasZ {
+            var zVal: Double = 0
+            guard GEOSGeomGetZ_r(geosObject.context.handle, geosObject.pointer, &zVal) == 1 else {
+                throw GEOSError.libraryError(errorMessages: geosObject.context.errors)
+            }
+            z = zVal
+        }
+
+        self.init(x: x, y: y, z: z)
     }
 }
 

--- a/Tests/GEOSwiftTests/Codable/LineString+CodableTests.swift
+++ b/Tests/GEOSwiftTests/Codable/LineString+CodableTests.swift
@@ -6,12 +6,19 @@ extension LineString {
     static let testJson1 = #"{"coordinates":[[1,2],[3,4]],"type":"LineString"}"#
 
     static let testValue5 = try! LineString(points: [.testValue5, .testValue7])
+    
+    static let testValueZ1 = try! LineString(points: [.testValueZ1, .testValueZ2])
+    static let testJsonZ1 = #"{"coordinates":[[1,2,3],[4,5,6]],"type":"LineString"}"#
 }
 
 @available(iOS 11.0, macOS 10.13, tvOS 11.0, *)
 final class LineString_CodableTests: CodableTestCase {
     func testCodable() {
         verifyCodable(with: LineString.testValue1, json: LineString.testJson1)
+    }
+    
+    func testCodableWithZ() {
+        verifyCodable(with: LineString.testValueZ1, json: LineString.testJsonZ1)
     }
 
     func testDecodableThrowsWithTypeMismatch() {

--- a/Tests/GEOSwiftTests/Codable/Point+CodableTests.swift
+++ b/Tests/GEOSwiftTests/Codable/Point+CodableTests.swift
@@ -10,12 +10,21 @@ extension Point {
     static let testValue5 = Point(x: 5, y: 6)
 
     static let testValue7 = Point(x: 7, y: 8)
+    
+    static let testValueZ1 = Point(x: 1, y: 2, z: 3)
+    static let testJsonZ1 = #"{"coordinates":[1,2,3],"type":"Point"}"#
+    
+    static let testValueZ2 = Point(x: 4, y: 5, z: 6)
 }
 
 @available(iOS 11.0, macOS 10.13, tvOS 11.0, *)
 final class Point_CodableTests: CodableTestCase {
     func testCodable() {
         verifyCodable(with: Point.testValue1, json: Point.testJson1)
+    }
+    
+    func testCodableWithZ() {
+        verifyCodable(with: Point.testValueZ1, json: Point.testJsonZ1)
     }
 
     func testDecodableThrowsWithLessThanTwoValues() {

--- a/Tests/GEOSwiftTests/Core Types/PointTests.swift
+++ b/Tests/GEOSwiftTests/Core Types/PointTests.swift
@@ -7,5 +7,14 @@ final class PointTests: XCTestCase {
 
         XCTAssertEqual(point.x, 1)
         XCTAssertEqual(point.y, 2)
+        XCTAssertNil(point.z)
+    }
+    
+    func testInitWithZ() {
+        let point = Point(x: 1, y: 2, z: 3)
+        
+        XCTAssertEqual(point.x, 1)
+        XCTAssertEqual(point.y, 2)
+        XCTAssertEqual(point.z, 3)
     }
 }

--- a/Tests/GEOSwiftTests/GEOS/Point+GEOSTests.swift
+++ b/Tests/GEOSwiftTests/GEOS/Point+GEOSTests.swift
@@ -5,6 +5,10 @@ final class Point_GEOSTests: GEOSContextTestCase {
     func testRoundtripToGEOS() {
         verifyRoundtripToGEOS(value: Point.testValue1)
     }
+    
+    func testRoundtripToGEOSWithZ() {
+        verifyRoundtripToGEOS(value: Point.testValueZ1)
+    }
 
     func testInitFromWrongGEOSType() {
         do {

--- a/Tests/GEOSwiftTests/GEOS/WKBTests.swift
+++ b/Tests/GEOSwiftTests/GEOS/WKBTests.swift
@@ -40,6 +40,11 @@ final class WKBTests: XCTestCase {
         verifyGeometryRoundtripToWKB(GeometryCollection.testValue)
         verifyGeometryRoundtripToWKB(GeometryCollection.testValueWithRecursion)
     }
+    
+    func testGeometryTypesRoundtripToWKBWithZ() {
+        verifyGeometryRoundtripToWKB(Point.testValueZ1)
+        verifyGeometryRoundtripToWKB(LineString.testValueZ1)
+    }
 
     func testLinearRingRoundtripToWKB() {
         let value = Polygon.LinearRing.testValueHole1

--- a/Tests/GEOSwiftTests/GEOS/WKTTests.swift
+++ b/Tests/GEOSwiftTests/GEOS/WKTTests.swift
@@ -41,6 +41,11 @@ final class WKTTests: XCTestCase {
         verifyGeometryRoundtripToWKT(GeometryCollection.testValue)
         verifyGeometryRoundtripToWKT(GeometryCollection.testValueWithRecursion)
     }
+    
+    func testGeometryTypesRoundtripToWKTWithZ() {
+        verifyGeometryRoundtripToWKT(Point.testValueZ1)
+        verifyGeometryRoundtripToWKT(LineString.testValueZ1)
+    }
 
     func verifyInitWithInvalidWKT<T>(type: T.Type, line: UInt = #line) where T: WKTInitializable {
         let invalidWKT = "invalid"


### PR DESCRIPTION
Closes #252 

Hi, I thought I would take a stab at adding z coordinate support. I think it's a real testament to the code quality of this project that it seemed pretty straightforward. This is a seriously nice codebase to work in. The lack of hardcoding of coordinate dimensionality in this library and the fact the GEOS supports and handles Z coordinates under the hood made this rather simple, but please let me know if I am missing anything.

## Design

I considered three different approaches:
1. Create a separate `Point` struct for 3D coordinates (e.g. `PointZ`, `Point3`) and follow this through to the other geometry types (e.g. `LineZ`).
2. Create a separate `Point` struct for 3D coordinates (e.g. `PointZ`, `Point3`) and extract a common `PointProtocol` interface for use by other types and algorithms. Create generics for dependent geometries over `PointProtocol`, (e.g. `LineString<Point>` and `LineString<PointZ>`.
3. Add an optional Z coordinate to the existing `Point` object 

I settled on option 3 for the following reasons:
* One of comments that I read was a desire to ensure that adding Z coordinates wouldn't make the API less ergonomic for the majority of users that just want X and Y. adding an optional Z parameter doesn't change the API for 2D users much at all beyond seeing the optional in autocomplete. The source is stable enough that it can probably be released as a minor version bump.
* Under the hood, GEOS seems to be working with points that optionally can have more than two dimension, so mirroring it in this API reduces friction and overhead.
* It extends 3D functionality to other geometry type quite organically

The only real downside I could see with this approach is that 3D users need to deal with an optional for Z. This feels acceptable because it's aligned with prioritizing 2D ergonomics as well being consistent with GEOS. If we wanted sacrifice a bit of 2D ergonomics to solve this, I believe the best approach would be to use a `PointProtocol` and make the other geometries generic over that. This would likely be a breaking change for existing 2D users.

## Implementation

* [x] Add Z coordinate as an optional parameter to `Point`
* [x] Update conversions to/from GeoJSON
* [x] Update conversions to/from WKB/WKT
* [x] Update conversions to/from GEOS
* [x] Add tests for the above
* [ ]  Consider additional helpers like a `Point.dimensions` count
* [ ] Clean up

Let me know what you think!